### PR TITLE
Improve parsing metadata propagation and status handling

### DIFF
--- a/scripts/clean/typing_status.py
+++ b/scripts/clean/typing_status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import datetime, UTC
-from typing import Dict, Optional, Tuple
+from typing import List, Optional, Tuple
 
 
 DATE_FMT = "%Y-%m-%d"
@@ -11,22 +11,32 @@ DATE_FMT = "%Y-%m-%d"
 
 @dataclass
 class DateParseResult:
+    raw: str
     value: Optional[datetime]
-    status: str  # DISCUSSED | NOT_DISCUSSED
+    status: str  # DISCUSSED | NOT_DISCUSSED | NOT_MENTIONED | PARSE_ERROR
+    error: Optional[str] = None
 
 
 ISO_PREFIX = "ISO_3166-1_ALPHA-2:"
 
+_STATUS_TOKENS = {
+    "NOT_DISCUSSED",
+    "NOT_MENTIONED",
+    "NOT_APPLICABLE",
+}
+
 
 def parse_date_field(raw: str) -> DateParseResult:
-    raw = (raw or "").strip()
-    if raw == "NOT_DISCUSSED":
-        return DateParseResult(value=None, status="NOT_DISCUSSED")
+    raw_norm = (raw or "").strip()
+    if not raw_norm:
+        return DateParseResult(raw="", value=None, status="NOT_MENTIONED")
+    if raw_norm in _STATUS_TOKENS:
+        return DateParseResult(raw=raw_norm, value=None, status=raw_norm)
     try:
-        dt = datetime.strptime(raw, DATE_FMT).replace(tzinfo=UTC)
-        return DateParseResult(value=dt, status="DISCUSSED")
-    except Exception:
-        return DateParseResult(value=None, status="NOT_DISCUSSED")
+        dt = datetime.strptime(raw_norm, DATE_FMT).replace(tzinfo=UTC)
+        return DateParseResult(raw=raw_norm, value=dt, status="DISCUSSED")
+    except Exception as exc:
+        return DateParseResult(raw=raw_norm, value=None, status="PARSE_ERROR", error=str(exc))
 
 
 def normalize_country(raw: str) -> Tuple[Optional[str], str]:
@@ -58,23 +68,108 @@ def _sanitize_numeric_string(raw: str) -> str:
     return s
 
 
-def parse_number(raw: str) -> Tuple[Optional[float], bool, str]:
-    # Returns (value, valid, status)
-    raw = (raw or "").strip()
-    if raw == "":
-        return None, True, "NOT_MENTIONED"
-    s = _sanitize_numeric_string(raw)
+@dataclass
+class NumericParseResult:
+    raw: str
+    value: Optional[float]
+    status: str  # DISCUSSED | NOT_MENTIONED | NOT_DISCUSSED | NOT_APPLICABLE | PARSE_ERROR | NEGATIVE_VALUE
+    valid: bool
+    error: Optional[str] = None
+
+
+_NUMERIC_STATUS_TOKENS = {
+    "NOT_DISCUSSED",
+    "NOT_MENTIONED",
+    "NOT_APPLICABLE",
+    "NONE",
+}
+
+
+def parse_number(raw: str) -> NumericParseResult:
+    raw_norm = (raw or "").strip()
+    if not raw_norm:
+        return NumericParseResult(raw="", value=None, status="NOT_MENTIONED", valid=True)
+    if raw_norm in _NUMERIC_STATUS_TOKENS:
+        return NumericParseResult(raw=raw_norm, value=None, status=raw_norm, valid=True)
+    s = _sanitize_numeric_string(raw_norm)
+    if not s:
+        return NumericParseResult(
+            raw=raw_norm,
+            value=None,
+            status="PARSE_ERROR",
+            valid=False,
+            error="sanitized_numeric_string_empty",
+        )
     try:
         val = float(s)
-        if val < 0:
-            return None, False, "DISCUSSED"
-        return val, True, "DISCUSSED"
-    except Exception:
-        return None, False, "DISCUSSED"
+    except Exception as exc:
+        return NumericParseResult(
+            raw=raw_norm,
+            value=None,
+            status="PARSE_ERROR",
+            valid=False,
+            error=str(exc),
+        )
+    if val < 0:
+        return NumericParseResult(
+            raw=raw_norm,
+            value=None,
+            status="NEGATIVE_VALUE",
+            valid=False,
+            error="value_lt_zero",
+        )
+    return NumericParseResult(raw=raw_norm, value=val, status="DISCUSSED", valid=True)
 
 
-def split_multiselect(raw: str) -> Tuple[list[str], str]:
-    if not raw:
-        return [], "NOT_MENTIONED"
-    tokens = [t.strip() for t in raw.split(",") if t.strip()]
-    return tokens, "DISCUSSED" if tokens else "NOT_MENTIONED"
+@dataclass
+class MultiSelectParseResult:
+    raw: str
+    tokens: List[str]
+    status: str
+
+
+def split_multiselect(raw: str) -> MultiSelectParseResult:
+    raw_norm = (raw or "").strip()
+    if not raw_norm:
+        return MultiSelectParseResult(raw="", tokens=[], status="NOT_MENTIONED")
+    tokens = [t.strip() for t in raw_norm.split(",") if t.strip()]
+    status = "DISCUSSED" if tokens else "NOT_MENTIONED"
+    return MultiSelectParseResult(raw=raw_norm, tokens=tokens, status=status)
+
+
+EXCLUSIVE_MARKERS = {
+    "NOT_APPLICABLE",
+    "NONE_MENTIONED",
+    "NONE_DISCUSSED",
+    "NONE",
+    "NOT_DETERMINED",
+}
+
+
+def derive_multiselect_status(qkey: str, tokens: List[str]) -> str:
+    if not tokens:
+        return "NOT_MENTIONED"
+    tset = set(tokens)
+    if qkey in {"Q31", "Q57"}:
+        if "NONE_VIOLATED" in tset:
+            return "NONE_VIOLATED"
+        if "NOT_DETERMINED" in tset:
+            return "NOT_DETERMINED"
+    if "NOT_APPLICABLE" in tset and all(t == "NOT_APPLICABLE" for t in tokens):
+        return "NOT_APPLICABLE"
+    if "NONE_MENTIONED" in tset and all(t == "NONE_MENTIONED" for t in tokens):
+        return "NONE_MENTIONED"
+    if qkey == "Q30" and "NONE_DISCUSSED" in tset and all(t == "NONE_DISCUSSED" for t in tokens):
+        return "NONE_DISCUSSED"
+    return "DISCUSSED"
+
+
+def detect_exclusivity_conflict(tokens: List[str]) -> int:
+    if not tokens:
+        return 0
+    tset = set(tokens)
+    markers = tset.intersection(EXCLUSIVE_MARKERS)
+    if not markers:
+        return 0
+    substantive = [t for t in tokens if t not in EXCLUSIVE_MARKERS]
+    return 1 if substantive else 0

--- a/tests/test_parser_and_clean.py
+++ b/tests/test_parser_and_clean.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from scripts.parser.ingest import segment_records, parse_record
-from scripts.clean.typing_status import parse_date_field, normalize_country
+from scripts.clean.typing_status import parse_date_field, normalize_country, parse_number
 from scripts.clean.isic_map import IsicIndex
 from scripts.clean.consistency import run_consistency_checks
 
@@ -23,6 +23,8 @@ class TestParserAndSegmentation(unittest.TestCase):
         parsed = parse_record(segs[0])
         self.assertTrue(parsed["metadata"]["completeness"])
         self.assertTrue(parsed["answers"]["Q1"].startswith("ISO_3166-1_ALPHA-2"))
+        self.assertIn("parser_version", parsed["metadata"])
+        self.assertEqual(parsed["metadata"]["question_count"], 68)
 
 
 class TestTypingAndCountry(unittest.TestCase):
@@ -30,9 +32,21 @@ class TestTypingAndCountry(unittest.TestCase):
         dpr = parse_date_field("2023-10-26")
         self.assertIsNotNone(dpr.value)
         self.assertEqual(dpr.status, "DISCUSSED")
+        self.assertEqual(dpr.raw, "2023-10-26")
+        err = parse_date_field("2023-13-40")
+        self.assertEqual(err.status, "PARSE_ERROR")
+        self.assertIsNone(err.value)
         code, status = normalize_country("ISO_3166-1_ALPHA-2: FR")
         self.assertEqual(code, "FR")
         self.assertEqual(status, "DISCUSSED")
+        num = parse_number("1,234.50")
+        self.assertTrue(num.valid)
+        self.assertAlmostEqual(num.value, 1234.50)
+        neg = parse_number("-5")
+        self.assertFalse(neg.valid)
+        self.assertEqual(neg.status, "NEGATIVE_VALUE")
+        missing = parse_number("")
+        self.assertEqual(missing.status, "NOT_MENTIONED")
 
 
 class TestISICAndConsistency(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add structured date, numeric, and multi-select parse results with explicit error states and exclusivity helpers
- propagate parser metadata into wide outputs, centralize response parsing, and capture parse errors in validation flags
- update long table emission, consistency checks, and tests to rely on the shared parsing utilities and cover new status cases

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6dd1a0b3c832eb3d4c3b222134f06