### PR TITLE
Normalize schema echo handling in exports

### DIFF
--- a/scripts-readme.md
+++ b/scripts-readme.md
@@ -8,6 +8,7 @@ This document summarizes every script that powers the DPA decision ingestion and
 2. ✅ **Enum whitelist metadata** – `build_enum_whitelist` records the actual prompt path in the emitted metadata, keeping provenance accurate when alternative questionnaires are parsed.【F:scripts/parser/enums.py†L23-L49】【F:scripts/cli.py†L25-L31】
 3. **Resource path resolution** – Multiple cleaning modules resolve optional assets (enum whitelist, ISIC structure) using bare relative paths such as `Path("resources/…")`, which breaks when the CLI runs outside the repository root.【F:scripts/clean/long_tables.py†L20-L28】【F:scripts/clean/wide_output.py†L92-L101】
    - *Plan*: centralize resource discovery (e.g., via `Path(__file__).resolve().parents[2]`) or allow explicit CLI arguments so callers can supply absolute paths; add regression tests that invoke the CLI from a temporary working directory.
+4. ✅ **Schema echo normalization drift** – Added `scripts.clean.schema_echo` so wide/long exports strip `TYPE:`, `ENUM:`, `MULTI_SELECT:` and `FORMAT:` prefixes uniformly, while still flagging affected questions for QA.【F:scripts/clean/schema_echo.py†L1-L34】【F:scripts/clean/wide_output.py†L145-L225】【F:scripts/clean/long_tables.py†L5-L126】
 
 ## Pipeline quick start
 

--- a/scripts/clean/schema_echo.py
+++ b/scripts/clean/schema_echo.py
@@ -1,0 +1,58 @@
+"""Utilities for handling schema echo artefacts in raw AI answers."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+
+SCHEMA_ECHO_PREFIXES = ("TYPE:", "ENUM:", "MULTI_SELECT:", "FORMAT:")
+
+
+def is_schema_echo(value: str) -> bool:
+    """Return True when ``value`` consists solely of a schema echo prefix."""
+
+    v = (value or "").strip()
+    return any(v.startswith(prefix) for prefix in SCHEMA_ECHO_PREFIXES)
+
+
+def strip_schema_echo(value: str) -> Tuple[str, bool]:
+    """Remove a leading schema echo prefix if present.
+
+    Parameters
+    ----------
+    value:
+        Raw answer token or field exported from the AI response.
+
+    Returns
+    -------
+    tuple[str, bool]
+        A tuple containing the cleaned value (with the prefix removed and
+        surrounding whitespace stripped) and a boolean indicating whether any
+        prefix was removed.
+    """
+
+    had_schema = False
+
+    def clean_token(token: str) -> str:
+        nonlocal had_schema
+        t = token.strip()
+        for prefix in SCHEMA_ECHO_PREFIXES:
+            if t.startswith(prefix):
+                had_schema = True
+                return t[len(prefix) :].lstrip()
+        return t
+
+    v = (value or "").strip()
+    if not v:
+        return "", False
+
+    if "," in v:
+        cleaned_tokens = [clean_token(part) for part in v.split(",")]
+        if had_schema:
+            filtered = [token for token in cleaned_tokens if token]
+            return ", ".join(filtered), True
+        return v, False
+
+    cleaned = clean_token(v)
+    return cleaned, had_schema
+


### PR DESCRIPTION
## Summary
- add a shared schema echo utility so both wide and long exporters strip TYPE:/ENUM:/MULTI_SELECT:/FORMAT: prefixes instead of dropping tokens
- update the wide exporter to persist cleaned raw_qXX values, keep QA flags in sync, and refresh the README guidance
- extend the regression suite with targeted fixtures that assert schema-prefixed answers round-trip through the wide CSV and long tables

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d7ec82c4b8832ea4cbf31832db93f9