### PR TITLE
Add long tables for early questionnaire multi-select fields

### DIFF
--- a/scripts/clean/long_tables.py
+++ b/scripts/clean/long_tables.py
@@ -11,7 +11,10 @@ from scripts.parser.validators import dedupe_preserve_order
 from scripts.parser.ingest import parse_record
 
 LONG_TABLE_QUESTIONS = {
+    "Q10",
     "Q21",
+    "Q25",
+    "Q28",
     "Q30",
     "Q31",
     "Q32",
@@ -72,6 +75,7 @@ class LongEmitter:
             fmt = _resolve_input_format(r.fieldnames, input_format)
 
             tables: Dict[str, List[Dict[str, str]]] = {
+                "defendant_classifications.csv": [],
                 "article_5_discussed.csv": [],
                 "article_5_violated.csv": [],
                 "article_6_discussed.csv": [],
@@ -79,6 +83,8 @@ class LongEmitter:
                 "consent_issues.csv": [],
                 "li_test_outcome.csv": [],
                 "breach_types.csv": [],
+                "special_data_categories.csv": [],
+                "mitigating_actions.csv": [],
                 "vulnerable_groups.csv": [],
                 "corrective_powers.csv": [],
                 "corrective_scopes.csv": [],
@@ -132,6 +138,10 @@ class LongEmitter:
                     if unknown:
                         tables[table_name].append({"decision_id": decision_id, "option": unknown[0], "status": "DISCUSSED", "token_status": "UNKNOWN"})
 
+                add_multiselect("Q10", "defendant_classifications.csv")
+                add_multiselect("Q21", "breach_types.csv")
+                add_multiselect("Q25", "special_data_categories.csv")
+                add_multiselect("Q28", "mitigating_actions.csv")
                 add_multiselect("Q30", "article_5_discussed.csv")
                 add_multiselect("Q31", "article_5_violated.csv")
                 add_multiselect("Q32", "article_6_discussed.csv")
@@ -139,7 +149,6 @@ class LongEmitter:
                 add_multiselect("Q34", "consent_issues.csv")
                 add_single("Q35", "li_test_outcome.csv")
 
-                add_multiselect("Q21", "breach_types.csv")
                 add_multiselect("Q46", "vulnerable_groups.csv")
 
                 add_multiselect("Q53", "corrective_powers.csv")

--- a/scripts/clean/wide_output.py
+++ b/scripts/clean/wide_output.py
@@ -41,6 +41,10 @@ TURNOVER_OUTLIER_HIGH = 1e12
 
 # Multi-select fields to emit systematically: (Qkey, prefix)
 MULTI_FIELDS: List[Tuple[str, str]] = [
+    ("Q10", "q10_org_class"),
+    ("Q21", "q21_breach_types"),
+    ("Q25", "q25_sensitive_data"),
+    ("Q28", "q28_mitigations"),
     ("Q30", "q30_discussed"),
     ("Q31", "q31_violated"),
     ("Q32", "q32_bases"),

--- a/scripts/export/arrow_export.py
+++ b/scripts/export/arrow_export.py
@@ -217,6 +217,8 @@ class ArrowExporter(BaseExporter):
         long_output.mkdir(exist_ok=True)
 
         tables = [
+            'defendant_classifications.csv', 'breach_types.csv',
+            'special_data_categories.csv', 'mitigating_actions.csv',
             'article_5_discussed.csv', 'article_5_violated.csv',
             'article_6_discussed.csv', 'corrective_powers.csv',
             'rights_discussed.csv', 'rights_violated.csv',

--- a/scripts/export/parquet_export.py
+++ b/scripts/export/parquet_export.py
@@ -210,6 +210,8 @@ class ParquetExporter(BaseExporter):
 
         # Key long tables for analysis
         tables = [
+            'defendant_classifications.csv', 'breach_types.csv',
+            'special_data_categories.csv', 'mitigating_actions.csv',
             'article_5_discussed.csv', 'article_5_violated.csv',
             'article_6_discussed.csv', 'corrective_powers.csv',
             'rights_discussed.csv', 'rights_violated.csv',

--- a/tests/test_parser_and_clean.py
+++ b/tests/test_parser_and_clean.py
@@ -165,9 +165,12 @@ class TestSchemaEchoNormalisation(unittest.TestCase):
                 "Q1": "ISO_3166-1_ALPHA-2: FR",
                 "Q2": "ENUM:CNIL",
                 "Q3": "2024-01-01",
+                "Q10": "ENUM:SME, ENUM:PUBLIC_SECTOR_BODY",
                 "Q12": "FORMAT:6209",
                 "Q15": "ENUM:COMPLAINT",
                 "Q21": "ENUM:SECURITY_INCIDENT, ENUM:OTHER",
+                "Q25": "ENUM:ARTICLE_9_SPECIAL_CATEGORY, ENUM:NEITHER",
+                "Q28": "ENUM:STAFF_TRAINING, ENUM:LEGAL_ADVICE",
                 "Q30": "ENUM:ACCOUNTABILITY, ENUM:SECURITY",
             }
         )
@@ -185,12 +188,18 @@ class TestSchemaEchoNormalisation(unittest.TestCase):
         row = rows[0]
         self.assertEqual(row["raw_q15"], "COMPLAINT")
         self.assertEqual(row["raw_q21"], "SECURITY_INCIDENT, OTHER")
+        self.assertEqual(row["raw_q10"], "SME, PUBLIC_SECTOR_BODY")
+        self.assertEqual(row["raw_q25"], "ARTICLE_9_SPECIAL_CATEGORY, NEITHER")
+        self.assertEqual(row["raw_q28"], "STAFF_TRAINING, LEGAL_ADVICE")
         self.assertEqual(row["raw_q30"], "ACCOUNTABILITY, SECURITY")
         flagged = set((row.get("schema_echo_fields") or "").split(";"))
         self.assertIn("Q2", flagged)
         self.assertIn("Q12", flagged)
         self.assertIn("Q15", flagged)
+        self.assertIn("Q10", flagged)
         self.assertIn("Q21", flagged)
+        self.assertIn("Q25", flagged)
+        self.assertIn("Q28", flagged)
         self.assertIn("Q30", flagged)
 
     def test_long_tables_emit_clean_tokens(self):
@@ -198,7 +207,10 @@ class TestSchemaEchoNormalisation(unittest.TestCase):
         response = self._response(
             {
                 "Q1": "ISO_3166-1_ALPHA-2: FR",
+                "Q10": "ENUM:SME, ENUM:PUBLIC_SECTOR_BODY",
                 "Q21": "ENUM:SECURITY_INCIDENT, ENUM:OTHER",
+                "Q25": "ENUM:ARTICLE_9_SPECIAL_CATEGORY",
+                "Q28": "ENUM:STAFF_TRAINING, ENUM:LEGAL_ADVICE",
                 "Q30": "ENUM:ACCOUNTABILITY, ENUM:SECURITY",
                 "Q33": "ENUM:CONSENT",
                 "Q35": "FORMAT:APPROVED",
@@ -213,9 +225,17 @@ class TestSchemaEchoNormalisation(unittest.TestCase):
         out_dir_raw = self.tmpdir / "long_raw"
         emitter_raw = LongEmitter(out_dir_raw)
         emitter_raw.emit_from_csv(raw_csv, input_format="raw")
+        class_rows = list(csv.DictReader((out_dir_raw / "defendant_classifications.csv").open(encoding="utf-8")))
+        self.assertTrue(any(r["option"] == "SME" for r in class_rows))
+        self.assertTrue(any(r["option"] == "PUBLIC_SECTOR_BODY" for r in class_rows))
         breach_rows = list(csv.DictReader((out_dir_raw / "breach_types.csv").open(encoding="utf-8")))
         self.assertTrue(any(r["option"] == "SECURITY_INCIDENT" for r in breach_rows))
         self.assertTrue(any(r["option"] == "OTHER" for r in breach_rows))
+        special_rows = list(csv.DictReader((out_dir_raw / "special_data_categories.csv").open(encoding="utf-8")))
+        self.assertTrue(any(r["option"] == "ARTICLE_9_SPECIAL_CATEGORY" for r in special_rows))
+        mitig_rows = list(csv.DictReader((out_dir_raw / "mitigating_actions.csv").open(encoding="utf-8")))
+        self.assertTrue(any(r["option"] == "STAFF_TRAINING" for r in mitig_rows))
+        self.assertTrue(any(r["option"] == "LEGAL_ADVICE" for r in mitig_rows))
 
         wide_csv = self.tmpdir / "wide.csv"
         report = self.tmpdir / "report.json"
@@ -223,6 +243,12 @@ class TestSchemaEchoNormalisation(unittest.TestCase):
         out_dir_wide = self.tmpdir / "long_wide"
         emitter_wide = LongEmitter(out_dir_wide)
         emitter_wide.emit_from_csv(wide_csv, input_format="wide")
+        class_rows_wide = list(csv.DictReader((out_dir_wide / "defendant_classifications.csv").open(encoding="utf-8")))
+        self.assertTrue(any(r["option"] == "SME" for r in class_rows_wide))
+        special_rows_wide = list(csv.DictReader((out_dir_wide / "special_data_categories.csv").open(encoding="utf-8")))
+        self.assertTrue(any(r["option"] == "ARTICLE_9_SPECIAL_CATEGORY" for r in special_rows_wide))
+        mitig_rows_wide = list(csv.DictReader((out_dir_wide / "mitigating_actions.csv").open(encoding="utf-8")))
+        self.assertTrue(any(r["option"] == "STAFF_TRAINING" for r in mitig_rows_wide))
         rights_rows = list(csv.DictReader((out_dir_wide / "article_5_discussed.csv").open(encoding="utf-8")))
         self.assertTrue(any(r["option"] == "ACCOUNTABILITY" for r in rights_rows))
         li_rows = list(csv.DictReader((out_dir_wide / "li_test_outcome.csv").open(encoding="utf-8")))


### PR DESCRIPTION
## Summary
- include Q10, Q25, and Q28 multi-select answers when emitting long-format tables and exporting Arrow/Parquet artifacts
- generate systematic wide-format columns for the added questions alongside existing breach-type coverage
- extend parser/cleaner tests to assert the new long tables and schema-echo handling for the early questionnaire fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7f089c0bc832ebde8f12280e30f2b