### PR TITLE
Handle NOT_DISCUSSED sentinel in multiselect status

### DIFF
--- a/scripts/clean/typing_status.py
+++ b/scripts/clean/typing_status.py
@@ -164,6 +164,7 @@ EXCLUSIVE_MARKERS = {
     "NOT_APPLICABLE",
     "NONE_MENTIONED",
     "NONE_DISCUSSED",
+    "NOT_DISCUSSED",
     "NONE",
     "NOT_DETERMINED",
     "NONE_VIOLATED",
@@ -187,6 +188,8 @@ def derive_multiselect_status(qkey: str, tokens: List[str]) -> str:
         return "NOT_APPLICABLE"
     if tset == {"NONE_MENTIONED"}:
         return "NONE_MENTIONED"
+    if tset == {"NOT_DISCUSSED"}:
+        return "NOT_DISCUSSED"
     if qkey == "Q30" and tset == {"NONE_DISCUSSED"}:
         return "NONE_DISCUSSED"
     return "DISCUSSED"

--- a/tests/test_parser_and_clean.py
+++ b/tests/test_parser_and_clean.py
@@ -103,6 +103,20 @@ class TestTypingAndCountry(unittest.TestCase):
             "MIXED_CONTRADICTORY",
         )
 
+        not_discussed_only = ["NOT_DISCUSSED"]
+        self.assertEqual(detect_exclusivity_conflict(not_discussed_only), 0)
+        self.assertEqual(
+            derive_multiselect_status("Q43", not_discussed_only),
+            "NOT_DISCUSSED",
+        )
+
+        not_discussed_conflict = ["NOT_DISCUSSED", "YES_MATERIAL_HARM"]
+        self.assertEqual(detect_exclusivity_conflict(not_discussed_conflict), 1)
+        self.assertEqual(
+            derive_multiselect_status("Q43", not_discussed_conflict),
+            "MIXED_CONTRADICTORY",
+        )
+
 
 class TestISICAndConsistency(unittest.TestCase):
     def test_isic_index_load(self):


### PR DESCRIPTION
## Summary
- treat NOT_DISCUSSED as an exclusive marker when deriving multiselect status
- return NOT_DISCUSSED when it is the sole token selected
- extend parser tests to cover NOT_DISCUSSED-only and mixed selections

## Testing
- pytest tests/test_parser_and_clean.py::TestTypingAndCountry::test_multiselect_exclusivity_conflicts

------
https://chatgpt.com/codex/tasks/task_e_68d7f93bd5a0832e9cd886ebf535963a