### PR TITLE
Add GDPR evenness analysis toolkit and protocol

### DIFF
--- a/research/evenness_analysis_protocol.md
+++ b/research/evenness_analysis_protocol.md
@@ -1,0 +1,137 @@
+# GDPR Enforcement Evenness Protocol
+
+## Overview
+
+This protocol operationalises the research goal of testing whether highly similar GDPR cases are treated evenly within and across jurisdictions, quantifying conditional disparities, and identifying institutional versus fact-driven drivers. It relies exclusively on structured questionnaire data covering 2018–2025 decisions and is designed to be reproducible via the CLI utilities under `scripts/evenness`.
+
+## Data Foundations
+
+- **Source**: `outputs/cleaned_wide_latest.csv` produced by the ingestion/cleaning pipeline in `scripts/cli.py`.
+- **Scope**: cases with structured answers Q1–Q68, including derived measures (`fine_log1p`, `enforcement_severity_index`, `n_principles_*`, etc.).
+- **Guardrails**:
+  - Respect `*_coverage_status`, `*_status`, and `*_exclusivity_conflict` columns. Indicator columns are nulled when coverage ≠ `DISCUSSED` or conflicts are flagged, preventing false positives from schema echoes.
+  - Treat `NOT_MENTIONED`, `NOT_APPLICABLE`, and `NONE` indicators as legally meaningful categories instead of NA.
+  - Multi-select prefixes used in the facts vector: `q21_breach_types`, `q25_sensitive_data`, `q46_vuln`, `q47_remedial`, `q53_powers`.
+  - Turnover variables (`turnover_*`) are only included through the selection-correction channel in robustness checks.
+  - UK mapping is preserved; ES/IT skew is handled in robustness reweighting (country-year weights).
+
+## Facts Vector (pre-outcome)
+
+| Domain | Columns / Construction |
+| --- | --- |
+| Breach & specials | `breach_case`, indicators from `q21_*`, `q25_*` (status-aware). |
+| Vulnerable groups | `q46_vuln_*` indicators (discussed-only). |
+| Remedial actions | `q47_remedial_*` indicators. |
+| Key powers | `q53_powers_*` indicators to observe severity signals. |
+| Sector & size | `isic_section`, `isic_code`, `organization_size_tier` (from `q10`), `organization_type` (`raw_q8`). |
+| Case origin | `case_origin` derived from `raw_q15`. |
+| Time | `decision_year`, `decision_quarter`, `days_since_gdpr`, `decision_year_bucket` (2018–19 / 2020–21 / 2022–23 / 2024–25). |
+| Geography | `country_code`, `dpa_name_canonical`, helper `country_year` for weights. |
+| Controls | `n_principles_violated`, `n_corrective_measures`, `severity_measures_present`, `remedy_only_case`. |
+
+Outcomes analysed: `fine_positive`, `fine_eur`, `fine_log1p`, `enforcement_severity_index`, and key corrective powers (from `q53_*`).
+
+## Matching Strategy
+
+1. **Exact / Coarsened Keys**
+   - `breach_case`, special data indicators (Article 9/10/Neither), `q46_vuln_CHILDREN`, `decision_year_bucket`, `isic_section`, and (for cross-country) `organization_type`.
+2. **Gower Nearest Neighbour Layer**
+   - Numeric: `days_since_gdpr`, `n_principles_violated`, `n_corrective_measures`.
+   - Categorical: within-country adds `organization_size_tier`, `organization_type`, `country_code`, `dpa_name_canonical`; cross-country excludes geography to permit international matches.
+   - Calipers: 0.30 (within), 0.25 (cross). Up to 3 (within) or 5 (cross) nearest neighbours per stratum.
+3. **Outputs & Diagnostics**
+   - Matched edge lists saved to `outputs/evenness/matches_within.csv` and `.../matches_cross.csv`.
+   - Standardised mean difference (SMD) balance charts produced via `plot_balance`.
+   - Common support assessed by reviewing caliper-trimmed distances in the edge list.
+
+## Conditional Disparity Modelling
+
+1. **Baseline Models (facts-only plus jurisdiction fixed effects)**
+   - Logistic GLM (`fine_positive ~ facts + C(country) + C(DPA)`), cluster-robust SEs by DPA.
+   - Weighted least squares for `fine_log1p` and `enforcement_severity_index`.
+2. **Mixed-Effects Specification**
+   - Linear mixed model with random intercepts `(1 | DPA)` and variance components `(1 | country)`; optional random slopes on `q25_sensitive_data_ARTICLE_9_SPECIAL_CATEGORY` and `q46_vuln_CHILDREN` to probe heterogeneous weighting of sensitive data/vulnerability.
+3. **Interaction Scan**
+   - Country × driver interactions tested individually, ranked by ΔAIC / LR statistic.
+4. **Outputs**
+   - JSON summaries under `outputs/evenness/models/` (`logistic.json`, `linear.json`, `mixed.json`).
+   - Interaction scan CSV for top drivers.
+
+## Leniency / Severity Index
+
+1. Regress outcomes (`fine_log1p`) on facts-only covariates to generate residuals.
+2. Fit partial pooling models:
+   - `(1 + drivers | DPA)` for DPA-level residualisation.
+   - `(1 | country)` for country-level pooling.
+3. Export DPA and country posterior means with 95% CIs to `outputs/evenness/leniency_index.csv` and plot the map to `.../leniency_map.png`.
+4. Variance components summarised (incl. ICC) via `outputs/evenness/variance_components.csv` and optional bar plot.
+
+## Variance & Driver Attribution
+
+- Intraclass correlations computed from mixed models (country vs. DPA vs. residual).
+- Oaxaca–Blinder decomposition between selected country pairs (e.g., high-volume vs. low-volume) saved per comparison.
+- Interaction scans highlight which factual drivers vary most across jurisdictions.
+
+## Robustness Package
+
+Executed with `python -m scripts.evenness.cli robustness`:
+
+| Scenario | Adjustment |
+| --- | --- |
+| `reweight_country_year` | Equalises influence across country-year cells. |
+| `heckman_turnover` | Applies control-function correction before introducing turnover. |
+| `discussed_only` | Drops rows where required prefixes are not discussed. |
+| `winsorize_fines` | Winsorises `fine_log1p` at the 99th percentile (and symmetrically). |
+| `quantile_75` / `quantile_90` | Quantile regression for τ=0.75/0.90 on `fine_log1p`. |
+
+All scenario outputs are JSON with model coefficients and audit notes placed under `outputs/evenness/robustness/`.
+
+Additional manual checks recommended:
+- Randomisation inference via shuffling `country_code` within match strata (edge list contains `stratum_key` for convenience).
+- Tail diagnostics using `quantile` scenarios.
+- Calibration of logistic model (`statsmodels` `GLMResults` supports `.predict()` for calibration curves).
+
+## Predictive Cross-Check
+
+- Gradient boosting models (classification for `fine_positive`, regression for `fine_log1p`) confirm non-linearities and interaction patterns.
+- SHAP summaries exported as PNGs and JSON metrics saved alongside model runs.
+- Serves as a validation of drivers identified in linear/mixed frameworks; not used for causal claims.
+
+## Command Summary
+
+```bash
+# 1. Build fact matrix
+python -m scripts.evenness.cli prepare-data --out outputs/evenness/fact_matrix.parquet
+
+# 2. Build matches and review balance
+python -m scripts.evenness.cli build-matches --balance-plot outputs/evenness/balance.png
+
+# 3. Fit conditional models
+python -m scripts.evenness.cli fit-models
+
+# 4. Generate leniency map & variance components
+python -m scripts.evenness.cli leniency-index --icc-plot outputs/evenness/icc.png
+
+# 5. Oaxaca between two jurisdictions
+python -m scripts.evenness.cli decompose --group-a FR --group-b DE
+
+# 6. Robustness battery
+python -m scripts.evenness.cli robustness
+
+# 7. Predictive SHAP cross-check
+python -m scripts.evenness.cli predictive --outcome fine_positive
+```
+
+## Deliverables
+
+1. **Methodology & Tooling** – This protocol, CLI documentation, and configuration files (see `scripts/evenness` package).
+2. **Reproducible Environment** – `research/evenness_environment.yml` capturing Python dependencies.
+3. **Execution Artefacts** – Fact matrix, match lists, model summaries, leniency map, variance tables, decomposition outputs, robustness JSONs, and SHAP plots under `outputs/evenness/` (created by CLI commands above).
+4. **Insights Report Template** – See `research/evenness_insights_report.md` (companion document) for structuring final findings (evenness verdicts, marginal effects, random-effect profiles, policy simulations).
+
+## Notes
+
+- All scripts default to reading the latest cleaned wide CSV; override `--wide-csv` to point to frozen snapshots.
+- The CLI honours guardrails automatically; no manual filtering of status columns is required.
+- Caliper and neighbour counts are exposed via `scripts/evenness/config.py` for experiment tuning.
+- For reproducibility, set `PYTHONHASHSEED` and supply a `--random-state` flag (future enhancement) if deterministic sampling is required beyond current deterministic operations.

--- a/research/evenness_environment.yml
+++ b/research/evenness_environment.yml
@@ -1,0 +1,20 @@
+name: gdpr-evenness
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+      - numpy
+      - pandas
+      - polars
+      - pyarrow
+      - statsmodels
+      - linearmodels
+      - scikit-learn
+      - seaborn
+      - matplotlib
+      - shap
+      - scipy
+      - tqdm
+      - gower

--- a/research/evenness_insights_report.md
+++ b/research/evenness_insights_report.md
@@ -1,0 +1,40 @@
+# GDPR Enforcement Evenness – Insights Report Template
+
+## Executive Summary
+- **Headline verdicts** on evenness within and across jurisdictions.
+- Key quantitative findings (effect sizes, variance shares, uncertainty intervals).
+- Policy-relevant recommendations based on simulated what-if adjustments.
+
+## Data & Matching Diagnostics
+- Dataset snapshot (time span, number of decisions, coverage filters applied).
+- Matching coverage table (within-country vs. cross-country pairs, average distances).
+- Balance diagnostics (embed/export SMD chart) and notes on common support.
+
+## Conditional Disparity Results
+- Logistic model marginal effects on `fine_positive` (with clustered CIs).
+- OLS / mixed-model coefficients for `fine_log1p` and `enforcement_severity_index`.
+- Highlight heterogeneity revealed by random slopes or interaction scans (country × driver effects).
+
+## Leniency / Severity Profiles
+- Leniency map (DPA-level residuals with CIs) and key outliers.
+- Country-level shrinkage estimates and variance decomposition (ICC chart).
+- Discussion of whether disparities are fact-driven or institutional.
+
+## Driver Attribution & Decomposition
+- Oaxaca–Blinder summaries for focal country pairs (explained vs. unexplained gaps).
+- Ranking of top discrepancy drivers (from interaction scan / SHAP interactions).
+- Narrative on vulnerable groups, sensitive data, and remedial action weighting.
+
+## Policy What-If Explorer
+- Simulated outcome shifts when toggling specific drivers (e.g., removing vulnerable group, switching initiation channel).
+- Stress tests for turnover inclusion using the selection-corrected scenario.
+- Cross-jurisdiction benchmarking: how lenient/severe jurisdictions converge under harmonised fact patterns.
+
+## Robustness Checks
+- Table summarising each robustness scenario, model shifts, and qualitative verdict (stable / notable change).
+- Notes on calibration, randomisation inference, and tail behaviour.
+
+## Appendix
+- Methodological references (link back to `research/evenness_analysis_protocol.md`).
+- CLI command log and environment hash (`conda env export` or `pip freeze`).
+- Data caveats (missing statuses, exclusivity conflicts, language issues).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,7 @@ CLI utilities for ingestion, validation, and cleaning of 68‑answer decision re
 ## Layout
 
 - `scripts/cli.py`: CLI entrypoint with subcommands
+- `scripts/evenness/`: Evenness analysis toolkit (matching, modelling, robustness)
 - `scripts/parser/ingest.py`: Segment blocks and extract Answer N: value pairs
 - `scripts/parser/enums.py`: Build ENUM/MULTI_SELECT/TYPE whitelist from the prompt
 - `scripts/clean/wide_output.py`: Generate cleaned wide CSV with enrichment and derived fields
@@ -62,6 +63,35 @@ python3 -m scripts.cli consistency \
 ```bash
 python3 -m scripts.cli run-all
 ```
+
+### Evenness research CLI
+
+High-level orchestration for the disparity study lives under `scripts.evenness.cli`.
+
+```bash
+# Build facts-only matrix honouring status flags
+python -m scripts.evenness.cli prepare-data --out outputs/evenness/fact_matrix.parquet
+
+# Construct within- and cross-country matches and plot balance diagnostics
+python -m scripts.evenness.cli build-matches --balance-plot outputs/evenness/balance.png
+
+# Fit logistic / OLS / mixed models with clustered SEs
+python -m scripts.evenness.cli fit-models
+
+# Generate leniency map and variance components
+python -m scripts.evenness.cli leniency-index --icc-plot outputs/evenness/icc.png
+
+# Run Oaxaca–Blinder between two countries
+python -m scripts.evenness.cli decompose --group-a FR --group-b DE
+
+# Fire the robustness battery (reweighting, Heckman, quantiles)
+python -m scripts.evenness.cli robustness
+
+# Optional gradient boosting + SHAP validation
+python -m scripts.evenness.cli predictive --outcome fine_positive
+```
+
+Artefacts land under `outputs/evenness/` by default (configurable via command flags).
 
 ## Outputs
 

--- a/scripts/evenness/__init__.py
+++ b/scripts/evenness/__init__.py
@@ -1,0 +1,40 @@
+"""GDPR evenness analysis toolkit."""
+from .config import (
+    EvennessPaths,
+    FACTS_CONFIG,
+    DEFAULT_MATCHING_WITHIN,
+    DEFAULT_MATCHING_CROSS,
+    LENIENCY_RANDOM_SLOPE_DRIVERS,
+    ROBUSTNESS_SCENARIOS,
+    required_fact_columns,
+)
+from .data import build_fact_matrix
+from .matching import perform_matching
+from .modeling import fit_logistic, fit_ols, fit_mixed_effects, model_to_dict
+from .leniency import compute_leniency_index
+from .variance import intraclass_correlation, variance_summary
+from .decomposition import run_oaxaca_blinder
+from .robustness import run_robustness_suite
+from .predictive import gradient_boosting_diagnostics
+
+__all__ = [
+    "EvennessPaths",
+    "FACTS_CONFIG",
+    "DEFAULT_MATCHING_WITHIN",
+    "DEFAULT_MATCHING_CROSS",
+    "LENIENCY_RANDOM_SLOPE_DRIVERS",
+    "ROBUSTNESS_SCENARIOS",
+    "required_fact_columns",
+    "build_fact_matrix",
+    "perform_matching",
+    "fit_logistic",
+    "fit_ols",
+    "fit_mixed_effects",
+    "model_to_dict",
+    "compute_leniency_index",
+    "intraclass_correlation",
+    "variance_summary",
+    "run_oaxaca_blinder",
+    "run_robustness_suite",
+    "gradient_boosting_diagnostics",
+]

--- a/scripts/evenness/cli.py
+++ b/scripts/evenness/cli.py
@@ -1,0 +1,322 @@
+"""Command line interface for the evenness analysis toolkit."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from .config import (
+    DEFAULT_MATCHING_CROSS,
+    DEFAULT_MATCHING_WITHIN,
+    EvennessPaths,
+    FACTS_CONFIG,
+    LENIENCY_RANDOM_SLOPE_DRIVERS,
+    ROBUSTNESS_SCENARIOS,
+)
+from .data import build_fact_matrix
+from .decomposition import run_oaxaca_blinder
+from .interaction import interaction_scan
+from .leniency import compute_leniency_index
+from .matching import perform_matching
+from .modeling import fit_logistic, fit_mixed_effects, fit_ols, model_to_dict
+from .plots import plot_balance, plot_icc_bars, plot_leniency_map, plot_shap_summary
+from .predictive import gradient_boosting_diagnostics
+from .robustness import run_robustness_suite
+from .variance import variance_summary
+
+
+def _load_fact_matrix(args: argparse.Namespace) -> pd.DataFrame:
+    return build_fact_matrix(args.wide_csv, discussed_only=getattr(args, "discussed_only", False))
+
+
+def _indicator_columns(df: pd.DataFrame) -> list[str]:
+    cols: list[str] = []
+    for prefix in FACTS_CONFIG.multi_value_prefixes:
+        indicator_cols = [
+            c
+            for c in df.columns
+            if c.startswith(f"{prefix}_")
+            and c
+            not in {
+                f"{prefix}_coverage_status",
+                f"{prefix}_status",
+                f"{prefix}_exclusivity_conflict",
+                f"{prefix}_known",
+                f"{prefix}_unknown",
+            }
+        ]
+        cols.extend(indicator_cols)
+    return cols
+
+
+def _categorical_columns() -> list[str]:
+    return ["breach_case", "organization_size_tier", "organization_type", "case_origin"]
+
+
+def _numeric_columns(df: pd.DataFrame) -> list[str]:
+    base = ["n_principles_violated", "n_corrective_measures", "days_since_gdpr"]
+    return [col for col in base if col in df.columns]
+
+
+def _build_formula(outcome: str, df: pd.DataFrame) -> str:
+    indicators = _indicator_columns(df)
+    numeric = _numeric_columns(df)
+    categorical = _categorical_columns()
+    terms: list[str] = []
+    terms.extend(indicators)
+    terms.extend(numeric)
+    terms.extend([f"C({col})" for col in categorical if col in df.columns])
+    terms.append("C(country_code)")
+    terms.append("C(dpa_name_canonical)")
+    rhs = " + ".join(dict.fromkeys(terms))
+    return f"{outcome} ~ {rhs}"
+
+
+def _compute_balance(df: pd.DataFrame, matches: pd.DataFrame, features: Sequence[str]) -> pd.DataFrame:
+    if matches.empty:
+        return pd.DataFrame(columns=["feature", "smd", "match_type"])
+    records: list[dict[str, object]] = []
+    index_df = df.set_index("decision_id")
+    for match_type, group in matches.groupby("match_type"):
+        for feature in features:
+            if feature not in index_df.columns:
+                continue
+            source = pd.to_numeric(index_df.loc[group["source_id"], feature], errors="coerce")
+            target = pd.to_numeric(index_df.loc[group["target_id"], feature], errors="coerce")
+            weights = group["weight"].to_numpy()
+            if source.isna().all() or target.isna().all():
+                continue
+            mean_s = np.average(source.fillna(source.mean()), weights=weights)
+            mean_t = np.average(target.fillna(target.mean()), weights=weights)
+            var_s = np.average((source - mean_s) ** 2, weights=weights)
+            var_t = np.average((target - mean_t) ** 2, weights=weights)
+            denom = np.sqrt((var_s + var_t) / 2)
+            if denom == 0:
+                continue
+            smd = (mean_s - mean_t) / denom
+            records.append({"feature": feature, "smd": smd, "match_type": match_type})
+    return pd.DataFrame(records)
+
+
+def cmd_prepare(args: argparse.Namespace) -> None:
+    df = build_fact_matrix(args.wide_csv, discussed_only=args.discussed_only)
+    out_path = Path(args.out or EvennessPaths().feature_cache)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if out_path.suffix == ".parquet":
+        df.to_parquet(out_path, index=False)
+    else:
+        df.to_csv(out_path, index=False)
+    print(f"Wrote fact matrix to {out_path}")
+
+
+def cmd_match(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    within = perform_matching(df, DEFAULT_MATCHING_WITHIN, within_country=True, match_type="within")
+    cross = perform_matching(df, DEFAULT_MATCHING_CROSS, within_country=False, match_type="cross")
+    paths = EvennessPaths()
+    paths.ensure()
+    within.to_csv(args.within_out or paths.match_within_csv, index=False)
+    cross.to_csv(args.cross_out or paths.match_cross_csv, index=False)
+    features = DEFAULT_MATCHING_WITHIN.gower_numeric
+    balance = pd.concat([
+        _compute_balance(df, within, features),
+        _compute_balance(df, cross, features),
+    ])
+    if args.balance_plot:
+        plot_balance(balance, Path(args.balance_plot))
+    print("Generated matching edges and balance diagnostics")
+
+
+def cmd_models(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    logistic_formula = _build_formula("fine_positive", df)
+    linear_formula = _build_formula("fine_log1p", df)
+    logistic = fit_logistic(df, logistic_formula, cluster_col="dpa_name_canonical")
+    linear = fit_ols(df, linear_formula, cluster_col="dpa_name_canonical")
+    random_terms = [term for term in ["q25_sensitive_data_ARTICLE_9_SPECIAL_CATEGORY", "q46_vuln_CHILDREN"] if term in df.columns]
+    re_formula = "1"
+    if random_terms:
+        re_formula = "1 + " + " + ".join(random_terms)
+    mixed = fit_mixed_effects(
+        df,
+        linear_formula,
+        group_col="dpa_name_canonical",
+        re_formula=re_formula,
+        vc_formula={"country": "0 + C(country_code)"},
+    )
+    out_dir = Path(args.model_dir or EvennessPaths().model_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "logistic.json").write_text(json.dumps(model_to_dict(logistic), indent=2))
+    (out_dir / "linear.json").write_text(json.dumps(model_to_dict(linear), indent=2))
+    (out_dir / "mixed.json").write_text(json.dumps(model_to_dict(mixed), indent=2))
+    print(f"Saved model summaries to {out_dir}")
+
+
+def cmd_leniency(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    result = compute_leniency_index(df, random_slope_terms=[t for t in LENIENCY_RANDOM_SLOPE_DRIVERS if t in df.columns])
+    paths = EvennessPaths()
+    paths.ensure()
+    result.frame.to_csv(args.out_csv or paths.leniency_csv, index=False)
+    plot_leniency_map(result.frame, Path(args.out_plot or paths.leniency_plot))
+    variance = variance_summary({"dpa": result.dpa_model, "country": result.country_model})
+    if args.icc_plot:
+        plot_icc_bars(variance, Path(args.icc_plot))
+    print("Computed leniency index and plots")
+
+
+def cmd_variance(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    result = compute_leniency_index(df)
+    variance = variance_summary({"dpa": result.dpa_model, "country": result.country_model})
+    out_path = Path(args.out or EvennessPaths().variance_csv)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    variance.to_csv(out_path, index=False)
+    print(f"Wrote variance components to {out_path}")
+
+
+def cmd_decompose(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    features = _indicator_columns(df) + _numeric_columns(df)
+    result = run_oaxaca_blinder(
+        df,
+        outcome=args.outcome,
+        group_col=args.group_col,
+        group_a=args.group_a,
+        group_b=args.group_b,
+        features=features,
+    )
+    out_dir = Path(args.out_dir or EvennessPaths().decomposition_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"oaxaca_{args.group_a}_vs_{args.group_b}_{args.outcome}.csv"
+    result.to_csv(out_path, index=False)
+    print(f"Wrote decomposition results to {out_path}")
+
+
+def cmd_robustness(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    logistic_formula = _build_formula("fine_positive", df)
+    linear_formula = _build_formula("fine_log1p", df)
+    outputs = run_robustness_suite(
+        df,
+        ROBUSTNESS_SCENARIOS,
+        logistic_formula,
+        linear_formula,
+        fact_features=_indicator_columns(df) + _numeric_columns(df),
+    )
+    out_dir = Path(args.out_dir or EvennessPaths().robustness_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, payload in outputs.items():
+        (out_dir / f"{name}.json").write_text(json.dumps(payload, indent=2))
+    print(f"Stored robustness results in {out_dir}")
+
+
+def cmd_interactions(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    base_formula = _build_formula(args.outcome, df)
+    result = interaction_scan(
+        df,
+        outcome=args.outcome,
+        base_formula=base_formula,
+        interaction_terms=_indicator_columns(df),
+    )
+    out_path = Path(args.out or EvennessPaths().model_dir / "interaction_scan.csv")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(out_path, index=False)
+    print(f"Wrote interaction scan to {out_path}")
+
+
+def cmd_predictive(args: argparse.Namespace) -> None:
+    df = _load_fact_matrix(args)
+    features = _indicator_columns(df) + _numeric_columns(df)
+    result = gradient_boosting_diagnostics(
+        df,
+        outcome=args.outcome,
+        feature_cols=features,
+        classification=args.outcome == "fine_positive",
+    )
+    out_dir = Path(args.out_dir or EvennessPaths().model_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / f"gb_{args.outcome}.json").write_text(
+        json.dumps({"metrics": result["metrics"]}, indent=2)
+    )
+    plot_shap_summary(result["shap_summary"], out_dir / f"shap_{args.outcome}.png")
+    print(f"Saved predictive diagnostics under {out_dir}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GDPR evenness analysis toolkit")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_prepare = sub.add_parser("prepare-data", help="Build fact matrix")
+    p_prepare.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_prepare.add_argument("--out")
+    p_prepare.add_argument("--discussed-only", action="store_true")
+    p_prepare.set_defaults(func=cmd_prepare)
+
+    p_match = sub.add_parser("build-matches", help="Construct matching edges")
+    p_match.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_match.add_argument("--within-out")
+    p_match.add_argument("--cross-out")
+    p_match.add_argument("--balance-plot")
+    p_match.set_defaults(func=cmd_match)
+
+    p_models = sub.add_parser("fit-models", help="Run conditional disparity models")
+    p_models.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_models.add_argument("--model-dir")
+    p_models.set_defaults(func=cmd_models)
+
+    p_leniency = sub.add_parser("leniency-index", help="Compute leniency/severity map")
+    p_leniency.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_leniency.add_argument("--out-csv")
+    p_leniency.add_argument("--out-plot")
+    p_leniency.add_argument("--icc-plot")
+    p_leniency.set_defaults(func=cmd_leniency)
+
+    p_variance = sub.add_parser("variance", help="Export variance components")
+    p_variance.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_variance.add_argument("--out")
+    p_variance.set_defaults(func=cmd_variance)
+
+    p_decomp = sub.add_parser("decompose", help="Run Oaxaca-Blinder decomposition")
+    p_decomp.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_decomp.add_argument("--outcome", default="fine_log1p")
+    p_decomp.add_argument("--group-col", default="country_code")
+    p_decomp.add_argument("--group-a", required=True)
+    p_decomp.add_argument("--group-b", required=True)
+    p_decomp.add_argument("--out-dir")
+    p_decomp.set_defaults(func=cmd_decompose)
+
+    p_robust = sub.add_parser("robustness", help="Run robustness suite")
+    p_robust.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_robust.add_argument("--out-dir")
+    p_robust.set_defaults(func=cmd_robustness)
+
+    p_interact = sub.add_parser("interaction-scan", help="Jurisdiction-driver interactions")
+    p_interact.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_interact.add_argument("--outcome", default="fine_log1p")
+    p_interact.add_argument("--out")
+    p_interact.set_defaults(func=cmd_interactions)
+
+    p_pred = sub.add_parser("predictive", help="Gradient boosting validation")
+    p_pred.add_argument("--wide-csv", default=EvennessPaths().wide_csv)
+    p_pred.add_argument("--outcome", default="fine_log1p")
+    p_pred.add_argument("--out-dir")
+    p_pred.set_defaults(func=cmd_predictive)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evenness/config.py
+++ b/scripts/evenness/config.py
@@ -1,0 +1,215 @@
+"""Configuration objects and defaults for the GDPR evenness analysis toolkit."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class EvennessPaths:
+    """Centralized file locations used by the CLI."""
+
+    wide_csv: Path = Path("outputs/cleaned_wide_latest.csv")
+    feature_cache: Path = Path("outputs/evenness/fact_matrix.parquet")
+    match_within_csv: Path = Path("outputs/evenness/matches_within.csv")
+    match_cross_csv: Path = Path("outputs/evenness/matches_cross.csv")
+    model_dir: Path = Path("outputs/evenness/models")
+    leniency_csv: Path = Path("outputs/evenness/leniency_index.csv")
+    leniency_plot: Path = Path("outputs/evenness/leniency_map.png")
+    variance_csv: Path = Path("outputs/evenness/variance_components.csv")
+    decomposition_dir: Path = Path("outputs/evenness/decomposition")
+    robustness_dir: Path = Path("outputs/evenness/robustness")
+
+    def ensure(self) -> None:
+        """Create parent directories for all registered artefacts."""
+
+        for path in (
+            self.feature_cache,
+            self.match_within_csv,
+            self.match_cross_csv,
+            self.model_dir,
+            self.leniency_csv,
+            self.leniency_plot,
+            self.variance_csv,
+            self.decomposition_dir,
+            self.robustness_dir,
+        ):
+            parent = Path(path).expanduser().resolve().parent
+            parent.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(frozen=True)
+class MatchingSpec:
+    """Specification for hybrid exact/Gower nearest-neighbour matching."""
+
+    exact_features: Sequence[str]
+    gower_numeric: Sequence[str]
+    gower_categorical: Sequence[str]
+    caliper: float = 0.35
+    neighbours: int = 3
+    min_group_size: int = 2
+
+    def all_features(self) -> Sequence[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for collection in (self.exact_features, self.gower_numeric, self.gower_categorical):
+            for name in collection:
+                if name not in seen:
+                    ordered.append(name)
+                    seen.add(name)
+        return tuple(ordered)
+
+
+@dataclass(frozen=True)
+class FactsConfig:
+    """Defines which columns comprise the 'facts-only' feature matrix."""
+
+    single_value_columns: Sequence[str] = (
+        "decision_id",
+        "breach_case",
+        "decision_year",
+        "decision_quarter",
+        "country_code",
+        "dpa_name_canonical",
+        "isic_section",
+        "isic_code",
+        "isic_desc",
+        "organization_size_tier",
+        "organization_type",
+        "case_origin",
+        "days_since_gdpr",
+    )
+    multi_value_prefixes: Sequence[str] = (
+        "q21_breach_types",
+        "q25_sensitive_data",
+        "q46_vuln",
+        "q47_remedial",
+        "q53_powers",
+    )
+    binary_columns: Sequence[str] = (
+        "fine_positive",
+    )
+    outcome_columns: Sequence[str] = (
+        "fine_positive",
+        "fine_eur",
+        "fine_log1p",
+        "enforcement_severity_index",
+    )
+
+    @property
+    def guardrail_prefixes(self) -> Sequence[str]:
+        """Prefixes that carry *_status/*_coverage metadata."""
+
+        return self.multi_value_prefixes + (
+            "q10_org_class",
+        )
+
+
+DEFAULT_MATCHING_WITHIN = MatchingSpec(
+    exact_features=(
+        "breach_case",
+        "q25_sensitive_data_ARTICLE_9_SPECIAL_CATEGORY",
+        "q25_sensitive_data_ARTICLE_10_CRIMINAL",
+        "q25_sensitive_data_NEITHER",
+        "q46_vuln_CHILDREN",
+        "decision_year_bucket",
+        "isic_section",
+    ),
+    gower_numeric=(
+        "days_since_gdpr",
+        "n_principles_violated",
+        "n_corrective_measures",
+    ),
+    gower_categorical=(
+        "country_code",
+        "dpa_name_canonical",
+        "organization_size_tier",
+        "organization_type",
+    ),
+    caliper=0.3,
+    neighbours=3,
+)
+
+DEFAULT_MATCHING_CROSS = MatchingSpec(
+    exact_features=(
+        "breach_case",
+        "q25_sensitive_data_ARTICLE_9_SPECIAL_CATEGORY",
+        "q25_sensitive_data_ARTICLE_10_CRIMINAL",
+        "q25_sensitive_data_NEITHER",
+        "q46_vuln_CHILDREN",
+        "decision_year_bucket",
+        "isic_section",
+        "organization_type",
+    ),
+    gower_numeric=(
+        "days_since_gdpr",
+        "n_principles_violated",
+        "n_corrective_measures",
+    ),
+    gower_categorical=(
+        "organization_size_tier",
+        "case_origin",
+        "dpa_name_canonical",
+    ),
+    caliper=0.25,
+    neighbours=5,
+)
+
+
+FACTS_CONFIG = FactsConfig()
+
+
+LENIENCY_RANDOM_SLOPE_DRIVERS: Sequence[str] = (
+    "breach_case",
+    "q46_vuln_CHILDREN",
+    "q25_sensitive_data_ARTICLE_9_SPECIAL_CATEGORY",
+    "organization_size_tier",
+)
+
+
+ROBUSTNESS_SCENARIOS: Mapping[str, Mapping[str, object]] = {
+    "reweight_country_year": {"weighting": "country_year"},
+    "heckman_turnover": {"selection": "turnover"},
+    "discussed_only": {"discussed_only": True},
+    "winsorize_fines": {"winsorize": 0.99},
+    "quantile_75": {"quantile": 0.75},
+    "quantile_90": {"quantile": 0.90},
+}
+
+
+def required_fact_columns() -> set[str]:
+    """Return the minimal set of columns required downstream."""
+
+    cols: set[str] = set()
+    cols.update(FACTS_CONFIG.single_value_columns)
+    cols.update(FACTS_CONFIG.binary_columns)
+    cols.update(FACTS_CONFIG.outcome_columns)
+    for prefix in FACTS_CONFIG.multi_value_prefixes:
+        cols.add(f"{prefix}_status")
+        cols.add(f"{prefix}_coverage_status")
+        cols.add(f"{prefix}_exclusivity_conflict")
+    # multi-value indicator columns will be collected dynamically
+    cols.update(
+        {
+            "n_principles_discussed",
+            "n_principles_violated",
+            "n_corrective_measures",
+            "severity_measures_present",
+            "remedy_only_case",
+        }
+    )
+    return cols
+
+
+__all__ = [
+    "EvennessPaths",
+    "MatchingSpec",
+    "FactsConfig",
+    "FACTS_CONFIG",
+    "DEFAULT_MATCHING_WITHIN",
+    "DEFAULT_MATCHING_CROSS",
+    "LENIENCY_RANDOM_SLOPE_DRIVERS",
+    "ROBUSTNESS_SCENARIOS",
+    "required_fact_columns",
+]

--- a/scripts/evenness/data.py
+++ b/scripts/evenness/data.py
@@ -1,0 +1,201 @@
+"""Data loading and feature preparation for the evenness analysis."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from .config import FACTS_CONFIG, EvennessPaths, required_fact_columns
+
+_GDPR_START = datetime(2018, 5, 25)
+
+
+def _ensure_datetime(series: pd.Series) -> pd.Series:
+    if pd.api.types.is_datetime64_any_dtype(series):
+        return series
+    return pd.to_datetime(series, errors="coerce", utc=True)
+
+
+def load_wide_dataset(path: Path | str | None = None, columns: Sequence[str] | None = None) -> pd.DataFrame:
+    """Load the cleaned wide CSV with minimal type coercion."""
+
+    csv_path = Path(path or EvennessPaths().wide_csv)
+    dtype_overrides = {"decision_id": str}
+    usecols = None
+    if columns is not None:
+        usecols = list(dict.fromkeys(columns))
+    df = pd.read_csv(csv_path, usecols=usecols, dtype=dtype_overrides)
+    if "decision_date" in df.columns:
+        df["decision_date"] = _ensure_datetime(df["decision_date"])
+    if "fine_eur" in df.columns:
+        df["fine_eur"] = pd.to_numeric(df["fine_eur"], errors="coerce")
+    if "fine_log1p" in df.columns:
+        df["fine_log1p"] = pd.to_numeric(df["fine_log1p"], errors="coerce")
+    if "enforcement_severity_index" in df.columns:
+        df["enforcement_severity_index"] = pd.to_numeric(
+            df["enforcement_severity_index"], errors="coerce"
+        )
+    return df
+
+
+def _sanitize_multiselect(df: pd.DataFrame, prefix: str) -> pd.DataFrame:
+    """Apply guardrails to multi-select indicator columns."""
+
+    coverage_col = f"{prefix}_coverage_status"
+    status_col = f"{prefix}_status"
+    conflict_col = f"{prefix}_exclusivity_conflict"
+    indicator_cols = [
+        c
+        for c in df.columns
+        if c.startswith(f"{prefix}_")
+        and c
+        not in {
+            coverage_col,
+            status_col,
+            conflict_col,
+            f"{prefix}_known",
+            f"{prefix}_unknown",
+        }
+    ]
+    if not indicator_cols:
+        return df
+
+    mask_discussed = pd.Series(True, index=df.index)
+    if coverage_col in df:
+        mask_discussed &= df[coverage_col].fillna("MISSING").eq("DISCUSSED")
+    if status_col in df:
+        mask_discussed &= df[status_col].fillna("MISSING").eq("DISCUSSED")
+    mask_conflict = pd.Series(False, index=df.index)
+    if conflict_col in df:
+        mask_conflict = df[conflict_col].fillna(False).astype(bool)
+
+    invalid = (~mask_discussed) | mask_conflict
+    if invalid.any():
+        df.loc[invalid, indicator_cols] = np.nan
+    return df
+
+
+def _derive_primary_category(df: pd.DataFrame, prefix: str, fallback_col: str | None = None) -> pd.Series:
+    indicator_cols = [
+        c
+        for c in df.columns
+        if c.startswith(f"{prefix}_")
+        and not c.endswith("_coverage_status")
+        and not c.endswith("_status")
+        and not c.endswith("_exclusivity_conflict")
+        and not c.endswith("_known")
+        and not c.endswith("_unknown")
+    ]
+    if not indicator_cols:
+        if fallback_col and fallback_col in df:
+            return df[fallback_col].fillna(pd.NA)
+        return pd.Series(pd.NA, index=df.index)
+
+    values = df[indicator_cols].copy()
+    for col in indicator_cols:
+        values[col] = pd.to_numeric(values[col], errors="coerce")
+    def collapse(row: pd.Series) -> str | pd.NA:
+        active = [col.split(f"{prefix}_", 1)[1] for col in indicator_cols if row.get(col, 0) == 1]
+        if not active:
+            return pd.NA
+        return "|".join(sorted(active))
+
+    series = values.apply(collapse, axis=1).astype("string")
+    if fallback_col and fallback_col in df:
+        series = series.fillna(df[fallback_col])
+    return series.astype("string")
+
+
+def _normalise_categorical(
+    series: pd.Series | None, index: pd.Index, default: str = "UNKNOWN"
+) -> pd.Series:
+    if series is None:
+        return pd.Series([default] * len(index), index=index, dtype="string")
+    filled = series.fillna(default).replace("", default)
+    return filled.astype("string")
+
+
+def build_fact_matrix(path: Path | str | None = None, discussed_only: bool = False) -> pd.DataFrame:
+    """Create the facts-only matrix used across the analysis steps."""
+
+    base_cols = required_fact_columns().union({
+        "raw_q8",
+        "raw_q10",
+        "raw_q15",
+        "decision_date",
+        "n_principles_discussed",
+    })
+    df = load_wide_dataset(path, columns=base_cols)
+
+    # Derive decision year/quarter if missing
+    if "decision_date" in df.columns and df["decision_date"].notna().any():
+        df["decision_year"] = df["decision_year"].fillna(df["decision_date"].dt.year)
+        df["decision_quarter"] = df["decision_quarter"].fillna(df["decision_date"].dt.quarter)
+        df["days_since_gdpr"] = (df["decision_date"] - _GDPR_START).dt.days
+    else:
+        df["days_since_gdpr"] = np.nan
+
+    df["days_since_gdpr"] = pd.to_numeric(df["days_since_gdpr"], errors="coerce")
+
+    # Apply guardrails
+    for prefix in FACTS_CONFIG.guardrail_prefixes:
+        if any(col.startswith(f"{prefix}_") for col in df.columns):
+            df = _sanitize_multiselect(df, prefix)
+
+    df["organization_size_tier"] = _derive_primary_category(df, "q10_org_class", "raw_q10")
+    df["organization_type"] = _normalise_categorical(df.get("raw_q8"), df.index)
+    df["case_origin"] = _normalise_categorical(df.get("raw_q15"), df.index)
+
+    df["decision_year_bucket"] = pd.cut(
+        df["decision_year"].fillna(-1),
+        bins=[2017, 2019, 2021, 2023, 2026],
+        labels=["2018-2019", "2020-2021", "2022-2023", "2024-2025"],
+        right=True,
+    ).astype(str)
+
+    # Derived helper columns
+    df["country_year"] = df["country_code"].astype(str) + "_" + df["decision_year"].fillna(-1).astype(int).astype(str)
+
+    if discussed_only:
+        for prefix in FACTS_CONFIG.multi_value_prefixes:
+            status_col = f"{prefix}_status"
+            if status_col in df:
+                mask = df[status_col].fillna("MISSING").eq("DISCUSSED")
+                df = df.loc[mask]
+
+    # Ensure multi-select indicator columns are numeric Int64
+    for prefix in FACTS_CONFIG.multi_value_prefixes:
+        indicator_cols = [
+            c
+            for c in df.columns
+            if c.startswith(f"{prefix}_")
+            and c
+            not in {
+                f"{prefix}_coverage_status",
+                f"{prefix}_status",
+                f"{prefix}_exclusivity_conflict",
+                f"{prefix}_known",
+                f"{prefix}_unknown",
+            }
+        ]
+        for col in indicator_cols:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
+
+    df["breach_case"] = _normalise_categorical(df.get("breach_case"), df.index)
+
+    numeric_fill_defaults = {
+        "n_principles_discussed": 0,
+        "n_principles_violated": 0,
+        "n_corrective_measures": 0,
+    }
+    for col, default in numeric_fill_defaults.items():
+        if col in df:
+            df[col] = pd.to_numeric(df[col], errors="coerce").fillna(default)
+
+    return df
+
+
+__all__ = ["build_fact_matrix", "load_wide_dataset"]

--- a/scripts/evenness/decomposition.py
+++ b/scripts/evenness/decomposition.py
@@ -1,0 +1,40 @@
+"""Disparity decomposition tools."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+from statsmodels.stats.oaxaca import OaxacaBlinder
+
+
+def run_oaxaca_blinder(
+    data: pd.DataFrame,
+    outcome: str,
+    group_col: str,
+    group_a: str,
+    group_b: str,
+    features: Sequence[str],
+    weight_col: str | None = None,
+) -> pd.DataFrame:
+    subset = data.loc[data[group_col].isin([group_a, group_b])].copy()
+    subset = subset.dropna(subset=list(features) + [outcome])
+    if subset.empty:
+        return pd.DataFrame()
+    weights = subset[weight_col] if weight_col else None
+    model = OaxacaBlinder(
+        subset[outcome],
+        subset[list(features)],
+        subset[group_col].eq(group_a).astype(int),
+        hasconst=False,
+        weights=weights,
+    )
+    results = model.blinder_oaxaca()
+    parts = {
+        "explained": results.explained,
+        "unexplained": results.unexplained,
+        "overall": results.mean_group1 - results.mean_group0,
+    }
+    return pd.DataFrame([{**parts, "group_a": group_a, "group_b": group_b, "outcome": outcome}])
+
+
+__all__ = ["run_oaxaca_blinder"]

--- a/scripts/evenness/interaction.py
+++ b/scripts/evenness/interaction.py
@@ -1,0 +1,35 @@
+"""Jurisdiction-driver interaction diagnostics."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+import statsmodels.formula.api as smf
+
+
+def interaction_scan(
+    data: pd.DataFrame,
+    outcome: str,
+    base_formula: str,
+    interaction_terms: Iterable[str],
+    cluster_col: str | None = None,
+) -> pd.DataFrame:
+    base_model = smf.ols(base_formula, data=data).fit()
+    records: list[dict[str, float]] = []
+    for term in interaction_terms:
+        formula = base_formula + f" + C(country_code):{term}"
+        model = smf.ols(formula, data=data).fit()
+        delta_aic = model.aic - base_model.aic
+        lr_stat = 2 * (model.llf - base_model.llf)
+        records.append(
+            {
+                "term": term,
+                "delta_aic": delta_aic,
+                "lr_stat": lr_stat,
+                "pvalue": model.compare_lr_test(base_model)[1],
+            }
+        )
+    return pd.DataFrame(records).sort_values("delta_aic")
+
+
+__all__ = ["interaction_scan"]

--- a/scripts/evenness/leniency.py
+++ b/scripts/evenness/leniency.py
@@ -1,0 +1,106 @@
+"""Leniency and severity index construction."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+import statsmodels.formula.api as smf
+
+@dataclass
+class LeniencyResult:
+    frame: pd.DataFrame
+    base_model: object
+    dpa_model: object
+    country_model: object
+
+
+def _make_formula(outcome: str, features: Sequence[str]) -> str:
+    rhs = " + ".join(features)
+    return f"{outcome} ~ {rhs}" if rhs else f"{outcome} ~ 1"
+
+
+def compute_leniency_index(
+    data: pd.DataFrame,
+    outcome: str = "fine_log1p",
+    fact_features: Sequence[str] | None = None,
+    random_slope_terms: Sequence[str] | None = None,
+) -> LeniencyResult:
+    fact_features = fact_features or [
+        "breach_case",
+        "q25_sensitive_data_ARTICLE_9_SPECIAL_CATEGORY",
+        "q25_sensitive_data_ARTICLE_10_CRIMINAL",
+        "q25_sensitive_data_NEITHER",
+        "q46_vuln_CHILDREN",
+        "organization_size_tier",
+        "organization_type",
+        "case_origin",
+        "n_principles_violated",
+        "n_corrective_measures",
+        "days_since_gdpr",
+    ]
+    formula = _make_formula(outcome, fact_features)
+    base_model = smf.ols(formula, data=data).fit()
+    residuals = base_model.resid
+    working = data.copy()
+    working["leniency_residual"] = residuals
+
+    random_slope_terms = list(random_slope_terms or [])
+    re_formula = "1"
+    if random_slope_terms:
+        re_formula = "1 + " + " + ".join(random_slope_terms)
+
+    dpa_model = smf.mixedlm(
+        "leniency_residual ~ 1",
+        working,
+        groups=working["dpa_name_canonical"],
+        re_formula=re_formula,
+    ).fit(reml=True)
+
+    country_model = smf.mixedlm(
+        "leniency_residual ~ 1",
+        working,
+        groups=working["country_code"],
+    ).fit(reml=True)
+
+    dpa_var = float(dpa_model.cov_re.iloc[0, 0]) if dpa_model.cov_re.size else float("nan")
+    dpa_sd = float(np.sqrt(dpa_var)) if np.isfinite(dpa_var) else float("nan")
+    country_var = float(country_model.cov_re.iloc[0, 0]) if country_model.cov_re.size else float("nan")
+    country_sd = float(np.sqrt(country_var)) if np.isfinite(country_var) else float("nan")
+
+    records: list[dict[str, object]] = []
+    for dpa, effect in dpa_model.random_effects.items():
+        value = float(effect[0]) if hasattr(effect, "__iter__") else float(effect)
+        records.append(
+            {
+                "jurisdiction_level": "DPA",
+                "jurisdiction": dpa,
+                "effect": value,
+                "sd": dpa_sd,
+                "lower": value - 1.96 * dpa_sd if np.isfinite(dpa_sd) else np.nan,
+                "upper": value + 1.96 * dpa_sd if np.isfinite(dpa_sd) else np.nan,
+                "n_obs": int((working["dpa_name_canonical"] == dpa).sum()),
+            }
+        )
+
+    for country, effect in country_model.random_effects.items():
+        value = float(effect[0]) if hasattr(effect, "__iter__") else float(effect)
+        records.append(
+            {
+                "jurisdiction_level": "Country",
+                "jurisdiction": country,
+                "effect": value,
+                "sd": country_sd,
+                "lower": value - 1.96 * country_sd if np.isfinite(country_sd) else np.nan,
+                "upper": value + 1.96 * country_sd if np.isfinite(country_sd) else np.nan,
+                "n_obs": int((working["country_code"] == country).sum()),
+            }
+        )
+
+    frame = pd.DataFrame(records)
+    frame = frame.sort_values(["jurisdiction_level", "effect"], ascending=[True, False])
+    return LeniencyResult(frame=frame, base_model=base_model, dpa_model=dpa_model, country_model=country_model)
+
+
+__all__ = ["compute_leniency_index", "LeniencyResult"]

--- a/scripts/evenness/matching.py
+++ b/scripts/evenness/matching.py
@@ -1,0 +1,139 @@
+"""Hybrid exact/Gower matching utilities."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .config import MatchingSpec
+
+
+def _format_stratum_key(values: Sequence[object]) -> str:
+    parts = ["NA" if pd.isna(v) else str(v) for v in values]
+    return "|".join(parts)
+
+
+def _gower_distance_for_row(
+    row_idx: int,
+    candidate_idx: Iterable[int],
+    numeric: pd.DataFrame,
+    categorical: pd.DataFrame,
+    ranges: pd.Series,
+) -> pd.Series:
+    distances: dict[int, float] = {}
+    row_num = numeric.loc[row_idx] if not numeric.empty else pd.Series(dtype=float)
+    row_cat = categorical.loc[row_idx] if not categorical.empty else pd.Series(dtype="string")
+    for cand in candidate_idx:
+        cand_num = numeric.loc[cand] if not numeric.empty else pd.Series(dtype=float)
+        cand_cat = categorical.loc[cand] if not categorical.empty else pd.Series(dtype="string")
+        contrib = 0.0
+        denom = 0
+        if not numeric.empty:
+            for col, rng in ranges.items():
+                if col not in row_num.index:
+                    continue
+                r_val = row_num[col]
+                c_val = cand_num[col]
+                if pd.isna(r_val) or pd.isna(c_val):
+                    continue
+                if rng == 0 or pd.isna(rng):
+                    continue
+                contrib += abs(float(r_val) - float(c_val)) / float(rng)
+                denom += 1
+        if not categorical.empty:
+            for col in categorical.columns:
+                r_val = row_cat[col]
+                c_val = cand_cat[col]
+                if pd.isna(r_val) or pd.isna(c_val):
+                    continue
+                contrib += 0.0 if r_val == c_val else 1.0
+                denom += 1
+        distances[cand] = np.nan if denom == 0 else contrib / denom
+    return pd.Series(distances)
+
+
+def _prepare_numeric(block: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    if not columns:
+        return pd.DataFrame(index=block.index)
+    numeric = block.loc[:, list(columns)].apply(pd.to_numeric, errors="coerce")
+    return numeric
+
+
+def _prepare_categorical(block: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    if not columns:
+        return pd.DataFrame(index=block.index)
+    cat = block.loc[:, list(columns)].copy()
+    for col in cat.columns:
+        cat[col] = cat[col].astype("string")
+    return cat
+
+
+def perform_matching(
+    data: pd.DataFrame,
+    spec: MatchingSpec,
+    within_country: bool,
+    id_col: str = "decision_id",
+    match_type: str = "within",
+) -> pd.DataFrame:
+    """Run matching and return a tidy edge list."""
+
+    results: list[dict[str, object]] = []
+    if data.empty:
+        return pd.DataFrame(columns=["source_id", "target_id", "distance", "weight", "match_type", "stratum_key"])
+
+    numeric = _prepare_numeric(data, spec.gower_numeric)
+    categorical = _prepare_categorical(data, spec.gower_categorical)
+    ranges = numeric.max(skipna=True) - numeric.min(skipna=True)
+    ranges = ranges.replace({0: 1}).fillna(1)
+
+    grouped = data.groupby(list(spec.exact_features), dropna=False)
+    for key, block in grouped:
+        if len(block) < spec.min_group_size:
+            continue
+        stratum_key = _format_stratum_key(key if isinstance(key, tuple) else (key,))
+        block_numeric = numeric.loc[block.index]
+        block_categorical = categorical.loc[block.index]
+        block_ranges = block_numeric.max(skipna=True) - block_numeric.min(skipna=True)
+        block_ranges = block_ranges.replace({0: 1}).fillna(1)
+        for row_idx, row in block.iterrows():
+            if within_country:
+                mask = block["country_code"].astype(str) == str(row["country_code"])
+                candidates = block.loc[mask & (block.index != row_idx)]
+            else:
+                candidates = block.loc[block["country_code"].astype(str) != str(row["country_code"])]
+            if candidates.empty:
+                continue
+            distances = _gower_distance_for_row(
+                row_idx,
+                candidates.index,
+                block_numeric,
+                block_categorical,
+                block_ranges,
+            )
+            distances = distances.dropna()
+            if distances.empty:
+                continue
+            within_caliper = distances[distances <= spec.caliper]
+            if within_caliper.empty:
+                continue
+            top = within_caliper.sort_values().head(spec.neighbours)
+            weight = 1.0 / len(top)
+            for rank, (cand_idx, dist) in enumerate(top.items(), start=1):
+                results.append(
+                    {
+                        "source_id": row[id_col],
+                        "target_id": block.loc[cand_idx, id_col],
+                        "distance": float(dist),
+                        "weight": weight,
+                        "match_rank": rank,
+                        "match_type": match_type,
+                        "stratum_key": stratum_key,
+                        "source_country": row["country_code"],
+                        "target_country": block.loc[cand_idx, "country_code"],
+                    }
+                )
+    return pd.DataFrame(results)
+
+
+__all__ = ["perform_matching"]

--- a/scripts/evenness/modeling.py
+++ b/scripts/evenness/modeling.py
@@ -1,0 +1,79 @@
+"""Statistical models for conditional disparity estimation."""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+import numpy as np
+import pandas as pd
+import statsmodels.api as sm
+import statsmodels.formula.api as smf
+
+
+def _fit_with_cov_type(model, cluster_col: str | None, data: pd.DataFrame, **fit_kwargs):
+    if cluster_col:
+        return model.fit(cov_type="cluster", cov_kwds={"groups": data[cluster_col]}, **fit_kwargs)
+    return model.fit(**fit_kwargs)
+
+
+def fit_logistic(
+    data: pd.DataFrame,
+    formula: str,
+    weight_col: str | None = None,
+    cluster_col: str | None = None,
+) -> sm.regression.linear_model.RegressionResultsWrapper:
+    weights = data[weight_col] if weight_col else None
+    model = smf.glm(formula=formula, data=data, family=sm.families.Binomial(), freq_weights=weights)
+    return _fit_with_cov_type(model, cluster_col, data)
+
+
+def fit_ols(
+    data: pd.DataFrame,
+    formula: str,
+    weight_col: str | None = None,
+    cluster_col: str | None = None,
+) -> sm.regression.linear_model.RegressionResultsWrapper:
+    weights = data[weight_col] if weight_col else None
+    model = smf.wls(formula=formula, data=data, weights=weights if weight_col else None)
+    return _fit_with_cov_type(model, cluster_col, data)
+
+
+def fit_mixed_effects(
+    data: pd.DataFrame,
+    formula: str,
+    group_col: str,
+    re_formula: str | None = None,
+    vc_formula: Mapping[str, str] | None = None,
+    weight_col: str | None = None,
+) -> sm.regression.mixed_linear_model.MixedLMResults:
+    weights = data[weight_col] if weight_col else None
+    model = smf.mixedlm(formula, data, groups=data[group_col], re_formula=re_formula, vc_formula=vc_formula, weights=weights)
+    return model.fit(method="lbfgs", reml=True)
+
+
+def model_to_dict(result: Any) -> Dict[str, Any]:
+    summary = {
+        "params": result.params.to_dict(),
+        "bse": result.bse.to_dict(),
+        "pvalues": result.pvalues.to_dict(),
+        "aic": getattr(result, "aic", np.nan),
+        "bic": getattr(result, "bic", np.nan),
+        "deviance": getattr(result, "deviance", np.nan),
+        "nobs": float(getattr(result, "nobs", np.nan)),
+    }
+    if hasattr(result, "random_effects"):
+        summary["random_effects"] = {k: v.tolist() for k, v in result.random_effects.items()}
+    if hasattr(result, "cov_re"):
+        summary["cov_re"] = result.cov_re.tolist()
+    return summary
+
+
+def marginal_effects(result: sm.regression.linear_model.RegressionResultsWrapper, at: Mapping[str, float] | None = None) -> pd.DataFrame:
+    if not hasattr(result, "get_margeff"):
+        raise TypeError("Model does not support marginal effects")
+    margeff = result.get_margeff(at=at)
+    frame = margeff.summary_frame()
+    frame.index.name = "term"
+    return frame.reset_index()
+
+
+__all__ = ["fit_logistic", "fit_ols", "fit_mixed_effects", "model_to_dict", "marginal_effects"]

--- a/scripts/evenness/plots.py
+++ b/scripts/evenness/plots.py
@@ -1,0 +1,77 @@
+"""Plotting utilities for evenness analysis."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+
+sns.set_style("whitegrid")
+
+
+def plot_leniency_map(frame: pd.DataFrame, out_path: Path) -> None:
+    plt.figure(figsize=(12, 8))
+    order = frame.loc[frame["jurisdiction_level"] == "DPA"].sort_values("effect")["jurisdiction"]
+    subset = frame.loc[frame["jurisdiction_level"] == "DPA"]
+    sns.pointplot(
+        data=subset,
+        y="jurisdiction",
+        x="effect",
+        join=False,
+        errorbar=None,
+        order=order,
+        color="#1f77b4",
+    )
+    for _, row in subset.iterrows():
+        plt.plot([row["lower"], row["upper"]], [row["jurisdiction"], row["jurisdiction"]], color="#1f77b4")
+    plt.axvline(0, color="black", linewidth=1, linestyle="--")
+    plt.title("Leniency / Severity residual index (DPA-level)")
+    plt.xlabel("Residual (higher = more severe)")
+    plt.ylabel("DPA")
+    plt.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+def plot_icc_bars(frame: pd.DataFrame, out_path: Path) -> None:
+    plt.figure(figsize=(6, 4))
+    sns.barplot(data=frame, x="component", y="icc", color="#ff7f0e")
+    plt.ylabel("Intraclass Correlation")
+    plt.xlabel("Component")
+    plt.ylim(0, 1)
+    plt.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+def plot_balance(frame: pd.DataFrame, out_path: Path, threshold: float = 0.1) -> None:
+    plt.figure(figsize=(8, 6))
+    sns.barplot(data=frame, x="feature", y="smd", hue="match_type")
+    plt.axhline(threshold, color="black", linestyle="--", linewidth=1)
+    plt.axhline(-threshold, color="black", linestyle="--", linewidth=1)
+    plt.ylabel("Standardized Mean Difference")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+def plot_shap_summary(shap_summary: pd.DataFrame, out_path: Path, top_n: int = 20) -> None:
+    plt.figure(figsize=(10, 6))
+    subset = shap_summary.head(top_n)
+    sns.barplot(data=subset, x="mean_abs_shap", y="feature", color="#2ca02c")
+    plt.xlabel("Mean |SHAP|")
+    plt.ylabel("Feature")
+    plt.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path, dpi=200)
+    plt.close()
+
+
+__all__ = ["plot_leniency_map", "plot_icc_bars", "plot_balance", "plot_shap_summary"]

--- a/scripts/evenness/predictive.py
+++ b/scripts/evenness/predictive.py
@@ -1,0 +1,64 @@
+"""Supplementary gradient boosting diagnostics."""
+from __future__ import annotations
+
+from typing import Dict, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor
+from sklearn.metrics import accuracy_score, mean_squared_error, roc_auc_score
+from sklearn.model_selection import train_test_split
+import shap
+
+
+def _prepare_features(data: pd.DataFrame, feature_cols: Sequence[str]) -> pd.DataFrame:
+    X = pd.get_dummies(data[list(feature_cols)], dummy_na=True)
+    return X
+
+
+def gradient_boosting_diagnostics(
+    data: pd.DataFrame,
+    outcome: str,
+    feature_cols: Sequence[str],
+    classification: bool = False,
+    test_size: float = 0.3,
+    random_state: int = 42,
+) -> Dict[str, object]:
+    X = _prepare_features(data, feature_cols)
+    y = data[outcome]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y if classification else None
+    )
+    if classification:
+        model = GradientBoostingClassifier(random_state=random_state)
+    else:
+        model = GradientBoostingRegressor(random_state=random_state)
+    model.fit(X_train, y_train)
+    y_pred = model.predict(X_test)
+    if classification:
+        proba = model.predict_proba(X_test)[:, 1]
+        metrics = {
+            "accuracy": float(accuracy_score(y_test, y_pred)),
+            "roc_auc": float(roc_auc_score(y_test, proba)),
+        }
+    else:
+        metrics = {"rmse": float(np.sqrt(mean_squared_error(y_test, y_pred)))}
+    explainer = shap.TreeExplainer(model)
+    shap_values = explainer.shap_values(X_test)
+    interaction_values = explainer.shap_interaction_values(X_test)
+    mean_abs_shap = np.mean(np.abs(shap_values), axis=0)
+    shap_summary = (
+        pd.DataFrame({"feature": X_test.columns, "mean_abs_shap": mean_abs_shap})
+        .sort_values("mean_abs_shap", ascending=False)
+        .reset_index(drop=True)
+    )
+    return {
+        "model": model,
+        "metrics": metrics,
+        "shap_values": shap_values,
+        "interaction_values": interaction_values,
+        "shap_summary": shap_summary,
+    }
+
+
+__all__ = ["gradient_boosting_diagnostics"]

--- a/scripts/evenness/robustness.py
+++ b/scripts/evenness/robustness.py
@@ -1,0 +1,119 @@
+"""Robustness and sensitivity checks."""
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+import pandas as pd
+import statsmodels.formula.api as smf
+from scipy import stats
+
+from .config import FACTS_CONFIG
+from .modeling import fit_logistic, fit_ols, model_to_dict
+
+ScenarioResult = Dict[str, object]
+
+
+def _inverse_mills_ratio(linear_pred: np.ndarray) -> np.ndarray:
+    pdf = stats.norm.pdf(linear_pred)
+    cdf = stats.norm.cdf(linear_pred)
+    cdf = np.clip(cdf, 1e-9, 1 - 1e-9)
+    return pdf / cdf
+
+
+def _apply_selection_correction(df: pd.DataFrame, features: list[str]) -> tuple[pd.DataFrame, object]:
+    working = df.copy()
+    working["turnover_observed"] = working["turnover_log1p"].notna().astype(int)
+    formula = "turnover_observed ~ " + " + ".join(features)
+    probit = smf.probit(formula, data=working).fit(disp=False)
+    linear_pred = probit.predict(linear=True)
+    working["turnover_control"] = _inverse_mills_ratio(linear_pred)
+    return working, probit
+
+
+def _apply_winsorization(df: pd.DataFrame, column: str, quantile: float) -> pd.DataFrame:
+    upper = df[column].quantile(quantile)
+    lower = df[column].quantile(1 - quantile)
+    df = df.copy()
+    df[column] = df[column].clip(lower=lower, upper=upper)
+    return df
+
+
+def default_model_builder(
+    data: pd.DataFrame,
+    options: Mapping[str, object],
+    logistic_formula: str,
+    linear_formula: str,
+    cluster_col: str = "dpa_name_canonical",
+) -> Dict[str, object]:
+    logistic = fit_logistic(data, logistic_formula, cluster_col=cluster_col)
+    linear = fit_ols(data, linear_formula, cluster_col=cluster_col)
+    return {"logistic": model_to_dict(logistic), "linear": model_to_dict(linear)}
+
+
+def run_robustness_suite(
+    data: pd.DataFrame,
+    scenarios: Mapping[str, Mapping[str, object]],
+    logistic_formula: str,
+    linear_formula: str,
+    fact_features: list[str],
+    cluster_col: str = "dpa_name_canonical",
+) -> Dict[str, ScenarioResult]:
+    outputs: Dict[str, ScenarioResult] = {}
+    for name, options in scenarios.items():
+        working = data.copy()
+        notes: list[str] = []
+        if options.get("discussed_only"):
+            mask = pd.Series(True, index=working.index)
+            for prefix in FACTS_CONFIG.multi_value_prefixes:
+                status_col = f"{prefix}_status"
+                if status_col in working:
+                    mask &= working[status_col].fillna("MISSING").eq("DISCUSSED")
+            working = working.loc[mask]
+            notes.append("Filtered to discussed-only records")
+        if options.get("winsorize"):
+            working = _apply_winsorization(working, "fine_log1p", options["winsorize"])
+            notes.append(f"Winsorized fine_log1p at q={options['winsorize']}")
+        if options.get("quantile"):
+            quant_model = smf.quantreg(linear_formula, working).fit(q=options["quantile"])
+            outputs[name] = {
+                "type": "quantile",
+                "quantile": options["quantile"],
+                "params": quant_model.params.to_dict(),
+                "nobs": float(quant_model.nobs),
+                "notes": notes,
+            }
+            continue
+        if options.get("selection") == "turnover":
+            working, probit = _apply_selection_correction(working, fact_features)
+            notes.append("Applied turnover control function")
+        if options.get("weighting") == "country_year":
+            counts = working.groupby("country_year").size()
+            weights = 1.0 / counts
+            working["robust_weight"] = working["country_year"].map(weights)
+            notes.append("Applied country-year reweighting")
+            weight_col = "robust_weight"
+        else:
+            weight_col = None
+        logistic = fit_logistic(
+            working,
+            logistic_formula,
+            weight_col=weight_col,
+            cluster_col=cluster_col,
+        )
+        linear = fit_ols(
+            working,
+            linear_formula,
+            weight_col=weight_col,
+            cluster_col=cluster_col,
+        )
+        outputs[name] = {
+            "type": "glm_ols",
+            "logistic": model_to_dict(logistic),
+            "linear": model_to_dict(linear),
+            "notes": notes,
+            "nobs": float(len(working)),
+        }
+    return outputs
+
+
+__all__ = ["run_robustness_suite", "default_model_builder"]

--- a/scripts/evenness/variance.py
+++ b/scripts/evenness/variance.py
@@ -1,0 +1,36 @@
+"""Variance decomposition helpers."""
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+def intraclass_correlation(model) -> float:
+    if not hasattr(model, "cov_re"):
+        return float("nan")
+    re_var = float(model.cov_re.iloc[0, 0]) if model.cov_re.size else 0.0
+    resid = float(model.scale) if hasattr(model, "scale") else 0.0
+    denom = re_var + resid
+    return float(re_var / denom) if denom > 0 else float("nan")
+
+
+def variance_summary(models: Dict[str, object]) -> pd.DataFrame:
+    records: list[dict[str, float]] = []
+    for name, model in models.items():
+        re_var = float(model.cov_re.iloc[0, 0]) if hasattr(model, "cov_re") and model.cov_re.size else np.nan
+        resid = float(model.scale) if hasattr(model, "scale") else np.nan
+        icc = intraclass_correlation(model)
+        records.append(
+            {
+                "component": name,
+                "random_variance": re_var,
+                "residual_variance": resid,
+                "icc": icc,
+            }
+        )
+    return pd.DataFrame(records)
+
+
+__all__ = ["intraclass_correlation", "variance_summary"]

--- a/tests/test_evenness_cli.py
+++ b/tests/test_evenness_cli.py
@@ -1,0 +1,42 @@
+import pandas as pd
+
+from scripts.evenness import cli
+
+
+def test_build_formula_includes_fixed_effects():
+    df = pd.DataFrame(
+        {
+            "decision_id": ["A", "B"],
+            "breach_case": ["YES", "NO"],
+            "organization_size_tier": ["SME", "SME"],
+            "organization_type": ["ORGANIZATION", "ORGANIZATION"],
+            "case_origin": ["COMPLAINT", "BREACH_NOTIFICATION"],
+            "country_code": ["FR", "DE"],
+            "dpa_name_canonical": ["CNIL", "BfDI"],
+            "n_principles_violated": [1, 0],
+            "n_corrective_measures": [2, 1],
+            "days_since_gdpr": [100, 200],
+            "q21_breach_types_TECHNICAL_FAILURE": [1, 0],
+            "q21_breach_types_status": ["DISCUSSED", "DISCUSSED"],
+            "q21_breach_types_coverage_status": ["DISCUSSED", "DISCUSSED"],
+        }
+    )
+    formula = cli._build_formula("fine_positive", df)
+    assert formula.startswith("fine_positive ~")
+    assert "C(country_code)" in formula
+    assert "q21_breach_types_TECHNICAL_FAILURE" in formula
+
+
+def test_indicator_columns_ignore_guardrails():
+    df = pd.DataFrame(
+        {
+            "decision_id": ["1"],
+            "q46_vuln_status": ["DISCUSSED"],
+            "q46_vuln_coverage_status": ["DISCUSSED"],
+            "q46_vuln_CHILDREN": [1],
+            "q46_vuln_NONE_MENTIONED": [0],
+        }
+    )
+    cols = cli._indicator_columns(df)
+    assert "q46_vuln_CHILDREN" in cols
+    assert "q46_vuln_status" not in cols

--- a/tests/test_evenness_config.py
+++ b/tests/test_evenness_config.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from scripts.evenness import (
+    DEFAULT_MATCHING_CROSS,
+    DEFAULT_MATCHING_WITHIN,
+    FACTS_CONFIG,
+    required_fact_columns,
+)
+
+
+def test_matching_specs_have_unique_features():
+    assert len(set(DEFAULT_MATCHING_WITHIN.all_features())) == len(DEFAULT_MATCHING_WITHIN.all_features())
+    assert len(set(DEFAULT_MATCHING_CROSS.all_features())) == len(DEFAULT_MATCHING_CROSS.all_features())
+
+
+def test_required_fact_columns_cover_outcomes():
+    cols = required_fact_columns()
+    for field in FACTS_CONFIG.outcome_columns:
+        assert field in cols
+
+
+def test_multi_value_prefixes_produce_guardrails():
+    df = pd.DataFrame(
+        {
+            "q21_breach_types_coverage_status": ["DISCUSSED"],
+            "q21_breach_types_status": ["DISCUSSED"],
+            "q21_breach_types_TECHNICAL_FAILURE": [1],
+        }
+    )
+    assert any(col.startswith("q21_breach_types_") for col in df.columns)


### PR DESCRIPTION
## Summary
- add a dedicated `scripts/evenness` package with configuration, matching, modelling, robustness, plotting, and predictive utilities wired into a single CLI entrypoint
- document the research protocol, companion insights report template, and reproducible environment for running the evenness analysis
- extend automated coverage with sanity checks for the configuration and CLI helpers used by the new toolkit

## Testing
- pytest tests/test_evenness_config.py tests/test_evenness_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d82f6b0f38832e846a539936a34c98