### PR TITLE
Refine numeric parsing for schema-echoed fine amounts

### DIFF
--- a/scripts/clean/typing_status.py
+++ b/scripts/clean/typing_status.py
@@ -59,17 +59,29 @@ def normalize_country(raw: str) -> Tuple[Optional[str], str]:
 
 
 _NUM_ALLOWED = re.compile(r"[^0-9eE+\-\., ]+")
-_SCHEMA_TOKEN_RE = re.compile(r"(?:^|\s)(?:TYPE|ENUM|MULTI_SELECT):[A-Z0-9_]+", re.IGNORECASE)
+_SCHEMA_TOKEN_RE = re.compile(
+    r"(?:(^|\s))(?:TYPE|ENUM|MULTI_SELECT):([A-Z0-9_]+)", re.IGNORECASE
+)
 
 
 def _strip_schema_tokens(raw: str) -> str:
-    """Remove schema-echo artefacts like ``TYPE:NUMBER`` before sanitizing.
+    """Remove schema-echo artefacts like ``TYPE:NUMBER`` while keeping digits.
 
-    These tokens are emitted by the questionnaire schema and should not be
-    interpreted as part of the numeric value.
+    Older questionnaire exports occasionally echoed the schema token (e.g.
+    ``TYPE:150000`` or ``TYPE:NUMBER``).  We strip the token prefix but retain
+    any trailing digits so that ``TYPE:150000`` is interpreted as ``150000``
+    instead of disappearing during sanitisation.
     """
 
-    return _SCHEMA_TOKEN_RE.sub(" ", raw)
+    def repl(match: re.Match[str]) -> str:
+        prefix = match.group(1) or ""
+        value = match.group(2) or ""
+        numeric = re.search(r"[-+]?\d[0-9_]*", value)
+        if numeric:
+            return f"{prefix}{numeric.group(0)}"
+        return prefix
+
+    return _SCHEMA_TOKEN_RE.sub(repl, raw)
 
 
 def _sanitize_numeric_string(raw: str) -> str:

--- a/tests/test_parser_and_clean.py
+++ b/tests/test_parser_and_clean.py
@@ -68,6 +68,12 @@ class TestTypingAndCountry(unittest.TestCase):
         schema = parse_number("TYPE:NUMBER 150000")
         self.assertTrue(schema.valid)
         self.assertEqual(schema.value, 150000)
+        schema_compact = parse_number("TYPE:150000")
+        self.assertTrue(schema_compact.valid)
+        self.assertEqual(schema_compact.value, 150000)
+        schema_number_zero = parse_number("TYPE:NUMBER 0")
+        self.assertTrue(schema_number_zero.valid)
+        self.assertEqual(schema_number_zero.value, 0)
         schema_only = parse_number("TYPE:NUMBER")
         self.assertEqual(schema_only.status, "NOT_MENTIONED")
 


### PR DESCRIPTION
## Summary
- adjust schema token stripping to retain digits from TYPE-prefixed responses so numeric fine amounts survive sanitisation
- extend parser tests to cover TYPE:150000 and TYPE:NUMBER 0 inputs and ensure they are recognised as valid numbers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da75384c28832ea2250002825045c0