### PR TITLE
Add fine reconciliation script and document AI vs human discrepancies

### DIFF
--- a/research/fine_amounts_comparison.md
+++ b/research/fine_amounts_comparison.md
@@ -1,0 +1,38 @@
+# Fine Amount Comparison Snapshot
+
+This note summarises the discrepancy analysis between the AI-generated wide
+dataset (`outputs/cleaned_wide.csv`) and the human annotated fines from
+`raw-data/all_gdpr_fines_raw_human_annotations.csv`.  Figures were produced with
+`python -m scripts.analysis.fine_reconciliation compare --tolerance 1.0`.
+
+## Aggregate status counts
+
+| Status          | Records |
+|-----------------|---------|
+| Matches         | 697     |
+| Conflicts       | 417     |
+| AI missing      | 313     |
+| Human missing   | 637     |
+| Missing in both | 629     |
+| **Total**       | 2,693   |
+
+*Tolerance*: entries are treated as matches when the absolute difference is at
+most 1 EUR.
+
+## Top five conflicts by absolute Euro difference
+
+| Decision ID  | AI fine (EUR) | Human fine (EUR) | Δ (EUR) |
+|--------------|---------------|------------------|---------|
+| Ireland_40   | 0             | 210,000,000      | 210,000,000 |
+| Ireland_41   | 0             | 180,000,000      | 180,000,000 |
+| Norway_34    | 100,000,000   | 8,900,000        | 91,100,000 |
+| Hungary_56   | 80,000,000    | 200,000          | 79,800,000 |
+| Hungary_18   | 80,000,000    | 208,000          | 79,792,000 |
+
+## Currency coverage in human annotations
+
+Detected currencies (after normalisation): BGN, CZK, DKK, EUR, GBP, HRK, HUF,
+ISK, NOK, PLN, RON, SEK.
+
+These figures highlight the large backlog of fines that require updates from
+the human annotations—both for missing AI values and clear conflicts.

--- a/scripts/analysis/fine_reconciliation.py
+++ b/scripts/analysis/fine_reconciliation.py
@@ -1,0 +1,494 @@
+"""Utilities for comparing and reconciling GDPR fine amounts.
+
+This module reads the AI-extracted wide dataset together with the
+human-curated annotations and provides helpers to:
+
+* compute record-level comparisons between both sources; and
+* overwrite the AI values with human annotations when conflicts are found.
+
+The script exposes a small CLI with two subcommands::
+
+    python -m scripts.analysis.fine_reconciliation compare
+    python -m scripts.analysis.fine_reconciliation apply --output-csv outputs/cleaned_wide_with_human.csv
+
+Both commands default to the canonical dataset locations within the
+repository but allow overriding the paths for ad-hoc investigations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from scripts.clean.typing_status import NumericParseResult, parse_number
+from scripts.clean.wide_output import FINE_OUTLIER_HIGH
+
+# Approximate currency conversion rates to EUR.  These figures do not need to
+# be perfect – they only provide a deterministic, order-of-magnitude reference
+# for reconciling datasets that mix local currencies with Euro-denominated
+# amounts.
+CURRENCY_TO_EUR: Dict[str, float] = {
+    "EUR": 1.0,
+    "GBP": 1.17,
+    "SEK": 0.087,
+    "DKK": 0.134,
+    "NOK": 0.089,
+    "PLN": 0.23,
+    "RON": 0.20,
+    "BGN": 0.51,
+    "HUF": 0.0026,
+    "CZK": 0.041,
+    "ISK": 0.0068,
+    "HRK": 0.133,
+    "CHF": 1.05,
+    "USD": 0.92,
+}
+
+_CURRENCY_SYMBOLS: Sequence[Tuple[str, Tuple[str, ...]]] = (
+    ("EUR", ("EUR", "€", "EURO", "EUROS")),
+    ("GBP", ("GBP", "£", "POUND", "POUNDS", "STERLING")),
+    ("SEK", ("SEK", "SWEDISH KR", "KRONOR")),
+    ("DKK", ("DKK", "DANISH KR")),
+    ("NOK", ("NOK", "NORWEGIAN KR", "KRONER")),
+    ("PLN", ("PLN", "ZŁ", "ZL", "ZLOTY", "ZLOTI")),
+    ("RON", ("RON", "LEI")),
+    ("BGN", ("BGN", "LEV", "LEVA")),
+    ("HUF", ("HUF", "FT", "FORINT")),
+    ("CZK", ("CZK", "KČ", "KCS")),
+    ("ISK", ("ISK", "KRÓNA", "KRONA")),
+    ("HRK", ("HRK", "KUNA", "KN")),
+    ("CHF", ("CHF", "FRANC")),
+    ("USD", ("USD", "$", "DOLLAR")),
+)
+
+_CURRENCY_CODE_RE = re.compile(r"\b([A-Z]{3})\b")
+_ID_FIELD_FALLBACKS = ("ID", "\ufeffID", "DecisionID")
+
+
+@dataclass
+class FineRecord:
+    """Structured representation of a single fine observation."""
+
+    decision_id: str
+    amount_eur: Optional[float]
+    amount_native: Optional[float]
+    currency: Optional[str]
+    raw: str
+    source: str  # "ai" or "human"
+
+
+@dataclass
+class FineComparison:
+    """Record-by-record comparison payload."""
+
+    decision_id: str
+    ai_amount_eur: Optional[float]
+    ai_raw: str
+    human_amount_eur: Optional[float]
+    human_amount_native: Optional[float]
+    human_currency: Optional[str]
+    human_raw: str
+    status: str
+    difference_eur: Optional[float]
+
+
+@dataclass
+class ComparisonSummary:
+    """Aggregated counts derived from the comparison output."""
+
+    total: int
+    matches: int
+    conflicts: int
+    ai_missing: int
+    human_missing: int
+    missing_both: int
+
+    def to_dict(self) -> Dict[str, int]:
+        return {
+            "total": self.total,
+            "matches": self.matches,
+            "conflicts": self.conflicts,
+            "ai_missing": self.ai_missing,
+            "human_missing": self.human_missing,
+            "missing_both": self.missing_both,
+        }
+
+
+def _detect_currency(raw: str) -> Optional[str]:
+    if not raw:
+        return None
+    upper = raw.upper()
+    for currency, tokens in _CURRENCY_SYMBOLS:
+        if any(token in upper for token in tokens):
+            return currency
+    match = _CURRENCY_CODE_RE.search(upper)
+    if match and match.group(1) in CURRENCY_TO_EUR:
+        return match.group(1)
+    return None
+
+
+def _parse_numeric(value: str) -> Optional[float]:
+    result: NumericParseResult = parse_number(value)
+    return result.value if result.valid and result.value is not None else None
+
+
+def _extract_decision_id(row: Mapping[str, str]) -> Optional[str]:
+    for key in _ID_FIELD_FALLBACKS:
+        if key in row and row[key]:
+            return row[key]
+    return None
+
+
+def _format_float(value: Optional[float], digits: int = 6) -> str:
+    if value is None:
+        return ""
+    return f"{value:.{digits}f}"
+
+
+def load_ai_dataset(path: Path) -> List[Dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader)
+
+
+def load_ai_fines(rows: Iterable[Mapping[str, str]]) -> Dict[str, FineRecord]:
+    fines: Dict[str, FineRecord] = {}
+    for row in rows:
+        decision_id = row.get("decision_id")
+        if not decision_id:
+            continue
+        fine_eur = _parse_numeric(row.get("fine_eur", ""))
+        fines[decision_id] = FineRecord(
+            decision_id=decision_id,
+            amount_eur=fine_eur,
+            amount_native=fine_eur,  # AI data is already expressed in EUR.
+            currency="EUR" if fine_eur is not None else None,
+            raw=row.get("fine_raw", ""),
+            source="ai",
+        )
+    return fines
+
+
+def load_human_fines(path: Path) -> Dict[str, FineRecord]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fines: Dict[str, FineRecord] = {}
+        for row in reader:
+            decision_id = _extract_decision_id(row)
+            if not decision_id:
+                continue
+            raw_fine = (row.get("Fine") or "").strip()
+            numeric_raw = row.get("Fine_Numeric") or ""
+            amount_native = None
+            if numeric_raw.strip():
+                amount_native = _parse_numeric(numeric_raw)
+            if amount_native is None and raw_fine:
+                amount_native = _parse_numeric(raw_fine)
+            currency = _detect_currency(raw_fine)
+            amount_eur: Optional[float] = None
+            if amount_native is not None and currency:
+                rate = CURRENCY_TO_EUR.get(currency)
+                if rate:
+                    amount_eur = amount_native * rate
+            elif amount_native is not None:
+                # Assume EUR when the annotation provides a number but no
+                # explicit currency.  This mirrors the historical dataset
+                # where Euro amounts were often recorded without a suffix.
+                amount_eur = amount_native
+                currency = "EUR"
+            fines[decision_id] = FineRecord(
+                decision_id=decision_id,
+                amount_eur=amount_eur,
+                amount_native=amount_native,
+                currency=currency,
+                raw=raw_fine or numeric_raw.strip(),
+                source="human",
+            )
+    return fines
+
+
+def compare_fines(
+    ai_fines: Mapping[str, FineRecord],
+    human_fines: Mapping[str, FineRecord],
+    *,
+    tolerance: float = 1.0,
+) -> List[FineComparison]:
+    decision_ids = set(ai_fines) | set(human_fines)
+    comparisons: List[FineComparison] = []
+    for decision_id in sorted(decision_ids):
+        ai_record = ai_fines.get(decision_id)
+        human_record = human_fines.get(decision_id)
+        ai_amount = ai_record.amount_eur if ai_record else None
+        ai_raw = ai_record.raw if ai_record else ""
+        human_amount = human_record.amount_eur if human_record else None
+        human_native = human_record.amount_native if human_record else None
+        human_currency = human_record.currency if human_record else None
+        human_raw = human_record.raw if human_record else ""
+        difference = None
+        status = "MISSING_BOTH"
+        if ai_amount is None and human_amount is None:
+            status = "MISSING_BOTH"
+        elif ai_amount is None:
+            status = "AI_MISSING"
+            difference = None if human_amount is None else abs(human_amount)
+        elif human_amount is None:
+            status = "HUMAN_MISSING"
+            difference = None
+        else:
+            difference = abs(ai_amount - human_amount)
+            status = "MATCH" if difference <= tolerance else "CONFLICT"
+        comparisons.append(
+            FineComparison(
+                decision_id=decision_id,
+                ai_amount_eur=ai_amount,
+                ai_raw=ai_raw,
+                human_amount_eur=human_amount,
+                human_amount_native=human_native,
+                human_currency=human_currency,
+                human_raw=human_raw,
+                status=status,
+                difference_eur=difference,
+            )
+        )
+    return comparisons
+
+
+def summarise_comparisons(comparisons: Sequence[FineComparison]) -> ComparisonSummary:
+    total = len(comparisons)
+    matches = sum(1 for c in comparisons if c.status == "MATCH")
+    conflicts = sum(1 for c in comparisons if c.status == "CONFLICT")
+    ai_missing = sum(1 for c in comparisons if c.status == "AI_MISSING")
+    human_missing = sum(1 for c in comparisons if c.status == "HUMAN_MISSING")
+    missing_both = sum(1 for c in comparisons if c.status == "MISSING_BOTH")
+    return ComparisonSummary(
+        total=total,
+        matches=matches,
+        conflicts=conflicts,
+        ai_missing=ai_missing,
+        human_missing=human_missing,
+        missing_both=missing_both,
+    )
+
+
+def apply_human_overrides(
+    rows: Sequence[Mapping[str, str]],
+    human_fines: Mapping[str, FineRecord],
+) -> Tuple[List[Dict[str, str]], List[str]]:
+    """Return updated rows and a log of overridden decision IDs."""
+
+    updated_rows: List[Dict[str, str]] = []
+    overrides: List[str] = []
+    for row in rows:
+        row_copy = dict(row)
+        decision_id = row_copy.get("decision_id")
+        if decision_id and decision_id in human_fines:
+            human_record = human_fines[decision_id]
+            amount_eur = human_record.amount_eur
+            if amount_eur is not None:
+                overrides.append(decision_id)
+                row_copy["fine_eur"] = _format_float(amount_eur)
+                row_copy["fine_numeric_valid"] = "1"
+                row_copy["fine_positive"] = "1" if amount_eur > 0 else "0"
+                row_copy["fine_log1p"] = _format_float(math.log1p(amount_eur))
+                row_copy["fine_outlier_flag"] = (
+                    "1" if amount_eur > FINE_OUTLIER_HIGH else "0"
+                )
+                row_copy["fine_raw"] = human_record.raw
+                row_copy["fine_status"] = "DISCUSSED"
+                row_copy["fine_error"] = ""
+                # Maintain the fine-to-turnover ratio if turnover is available.
+                turnover = _parse_numeric(row_copy.get("turnover_eur", ""))
+                if turnover and turnover > 0:
+                    ratio = amount_eur / turnover
+                    row_copy["fine_to_turnover_ratio"] = f"{ratio:.8f}"
+                else:
+                    row_copy["fine_to_turnover_ratio"] = row_copy.get(
+                        "fine_to_turnover_ratio", ""
+                    )
+                row_copy.setdefault("fine_amount_human_native", "")
+                row_copy.setdefault("fine_amount_human_eur", "")
+                row_copy.setdefault("fine_currency_human", "")
+                if human_record.amount_native is not None:
+                    row_copy["fine_amount_human_native"] = _format_float(
+                        human_record.amount_native
+                    )
+                if human_record.amount_eur is not None:
+                    row_copy["fine_amount_human_eur"] = _format_float(
+                        human_record.amount_eur
+                    )
+                if human_record.currency:
+                    row_copy["fine_currency_human"] = human_record.currency
+        updated_rows.append(row_copy)
+    return updated_rows, overrides
+
+
+def write_csv(rows: Sequence[Mapping[str, str]], path: Path) -> None:
+    if not rows:
+        raise ValueError("Cannot write CSV with no rows")
+    fieldnames: List[str] = list(rows[0].keys())
+    for row in rows[1:]:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def write_comparison_csv(
+    comparisons: Sequence[FineComparison],
+    path: Path,
+) -> None:
+    fieldnames = [
+        "decision_id",
+        "ai_amount_eur",
+        "ai_raw",
+        "human_amount_eur",
+        "human_amount_native",
+        "human_currency",
+        "human_raw",
+        "status",
+        "difference_eur",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for comp in comparisons:
+            writer.writerow(
+                {
+                    "decision_id": comp.decision_id,
+                    "ai_amount_eur": _format_float(comp.ai_amount_eur),
+                    "ai_raw": comp.ai_raw,
+                    "human_amount_eur": _format_float(comp.human_amount_eur),
+                    "human_amount_native": _format_float(
+                        comp.human_amount_native
+                    ),
+                    "human_currency": comp.human_currency or "",
+                    "human_raw": comp.human_raw,
+                    "status": comp.status,
+                    "difference_eur": _format_float(comp.difference_eur),
+                }
+            )
+
+
+def _cli_compare(args: argparse.Namespace) -> int:
+    ai_rows = load_ai_dataset(args.ai_csv)
+    ai_fines = load_ai_fines(ai_rows)
+    human_fines = load_human_fines(args.human_csv)
+    comparisons = compare_fines(ai_fines, human_fines, tolerance=args.tolerance)
+    summary = summarise_comparisons(comparisons)
+    print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))
+    if args.out_csv:
+        write_comparison_csv(comparisons, args.out_csv)
+    if args.summary_out:
+        with args.summary_out.open("w", encoding="utf-8") as handle:
+            json.dump(summary.to_dict(), handle, indent=2, sort_keys=True)
+    if args.limit and args.limit > 0:
+        conflicts = [c for c in comparisons if c.status == "CONFLICT"]
+        conflicts.sort(key=lambda c: (c.difference_eur or 0), reverse=True)
+        preview = conflicts[: args.limit]
+        if preview:
+            print("Top conflicts (decision_id, ai_eur, human_eur, diff):")
+            for comp in preview:
+                print(
+                    f"  {comp.decision_id}: {comp.ai_amount_eur} vs {comp.human_amount_eur} (Δ={comp.difference_eur})"
+                )
+    return 0
+
+
+def _cli_apply(args: argparse.Namespace) -> int:
+    ai_rows = load_ai_dataset(args.ai_csv)
+    human_fines = load_human_fines(args.human_csv)
+    updated_rows, overrides = apply_human_overrides(ai_rows, human_fines)
+    write_csv(updated_rows, args.output_csv)
+    if overrides:
+        print(f"Updated {len(overrides)} records from human annotations.")
+    else:
+        print("No overrides were applied.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    compare_parser = subparsers.add_parser(
+        "compare", help="Generate a comparison between AI and human fines"
+    )
+    compare_parser.add_argument(
+        "--ai-csv",
+        type=Path,
+        default=Path("outputs/cleaned_wide.csv"),
+        help="Path to the AI-generated wide dataset.",
+    )
+    compare_parser.add_argument(
+        "--human-csv",
+        type=Path,
+        default=Path("raw-data/all_gdpr_fines_raw_human_annotations.csv"),
+        help="Path to the human annotated fines.",
+    )
+    compare_parser.add_argument(
+        "--out-csv",
+        type=Path,
+        help="Optional path to write the detailed comparison table.",
+    )
+    compare_parser.add_argument(
+        "--summary-out",
+        type=Path,
+        help="Optional path to write the aggregate summary as JSON.",
+    )
+    compare_parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=1.0,
+        help="Difference tolerance (in EUR) treated as a match.",
+    )
+    compare_parser.add_argument(
+        "--limit",
+        type=int,
+        help="Print the top-N conflicting rows to stdout.",
+    )
+    compare_parser.set_defaults(func=_cli_compare)
+
+    apply_parser = subparsers.add_parser(
+        "apply", help="Overwrite AI fines with human annotations"
+    )
+    apply_parser.add_argument(
+        "--ai-csv",
+        type=Path,
+        default=Path("outputs/cleaned_wide.csv"),
+        help="Path to the AI-generated wide dataset.",
+    )
+    apply_parser.add_argument(
+        "--human-csv",
+        type=Path,
+        default=Path("raw-data/all_gdpr_fines_raw_human_annotations.csv"),
+        help="Path to the human annotated fines.",
+    )
+    apply_parser.add_argument(
+        "--output-csv",
+        type=Path,
+        required=True,
+        help="Destination for the reconciled dataset.",
+    )
+    apply_parser.set_defaults(func=_cli_apply)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fine_reconciliation.py
+++ b/tests/test_fine_reconciliation.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+
+import pytest
+
+from scripts.analysis.fine_reconciliation import (
+    ComparisonSummary,
+    FineRecord,
+    apply_human_overrides,
+    compare_fines,
+    load_human_fines,
+    summarise_comparisons,
+)
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_load_human_fines_parses_currency_and_amount(tmp_path: Path) -> None:
+    human_path = tmp_path / "human.csv"
+    fieldnames = ["\ufeffID", "Fine", "Fine_Numeric"]
+    rows = [
+        {"\ufeffID": "Case1", "Fine": "5,000 EUR", "Fine_Numeric": "5000"},
+        {"\ufeffID": "Case2", "Fine": "10 000 GBP", "Fine_Numeric": "10000"},
+        {"\ufeffID": "Case3", "Fine": "150000", "Fine_Numeric": ""},
+    ]
+    _write_csv(human_path, fieldnames, rows)
+
+    fines = load_human_fines(human_path)
+
+    assert "Case1" in fines
+    assert fines["Case1"].currency == "EUR"
+    assert fines["Case1"].amount_native == pytest.approx(5000.0)
+    assert fines["Case1"].amount_eur == pytest.approx(5000.0)
+
+    assert fines["Case2"].currency == "GBP"
+    assert fines["Case2"].amount_native == pytest.approx(10000.0)
+    assert fines["Case2"].amount_eur == pytest.approx(11700.0)
+
+    # Without an explicit currency we assume the amount is already in EUR.
+    assert fines["Case3"].currency == "EUR"
+    assert fines["Case3"].amount_eur == pytest.approx(150000.0)
+
+
+def test_apply_human_overrides_updates_numeric_fields(tmp_path: Path) -> None:
+    ai_rows = [
+        {
+            "decision_id": "Case1",
+            "fine_eur": "100.000000",
+            "fine_numeric_valid": "1",
+            "fine_positive": "1",
+            "fine_log1p": f"{math.log1p(100):.6f}",
+            "fine_outlier_flag": "0",
+            "fine_raw": "TYPE:NUMBER 100",
+            "fine_status": "DISCUSSED",
+            "fine_error": "",
+            "turnover_eur": "1000.000000",
+            "fine_to_turnover_ratio": f"{100/1000:.8f}",
+        },
+        {
+            "decision_id": "Case2",
+            "fine_eur": "200.000000",
+            "fine_numeric_valid": "1",
+            "fine_positive": "1",
+            "fine_log1p": f"{math.log1p(200):.6f}",
+            "fine_outlier_flag": "0",
+            "fine_raw": "TYPE:NUMBER 200",
+            "fine_status": "DISCUSSED",
+            "fine_error": "",
+            "turnover_eur": "600.000000",
+            "fine_to_turnover_ratio": f"{200/600:.8f}",
+        },
+        {
+            "decision_id": "Case3",
+            "fine_eur": "",
+            "fine_numeric_valid": "0",
+            "fine_positive": "0",
+            "fine_log1p": "",
+            "fine_outlier_flag": "0",
+            "fine_raw": "",
+            "fine_status": "NOT_MENTIONED",
+            "fine_error": "",
+            "turnover_eur": "",
+            "fine_to_turnover_ratio": "",
+        },
+        {
+            "decision_id": "Case4",
+            "fine_eur": "50.000000",
+            "fine_numeric_valid": "1",
+            "fine_positive": "1",
+            "fine_log1p": f"{math.log1p(50):.6f}",
+            "fine_outlier_flag": "0",
+            "fine_raw": "TYPE:NUMBER 50",
+            "fine_status": "DISCUSSED",
+            "fine_error": "",
+            "turnover_eur": "",
+            "fine_to_turnover_ratio": "",
+        },
+    ]
+
+    human_path = tmp_path / "human.csv"
+    fieldnames = ["\ufeffID", "Fine", "Fine_Numeric"]
+    human_rows = [
+        {"\ufeffID": "Case1", "Fine": "100 EUR", "Fine_Numeric": "100"},
+        {"\ufeffID": "Case2", "Fine": "300 EUR", "Fine_Numeric": "300"},
+        {"\ufeffID": "Case3", "Fine": "1,000 GBP", "Fine_Numeric": "1000"},
+    ]
+    _write_csv(human_path, fieldnames, human_rows)
+    human_fines = load_human_fines(human_path)
+
+    updated_rows, overrides = apply_human_overrides(ai_rows, human_fines)
+
+    assert overrides == ["Case1", "Case2", "Case3"]
+
+    # Case1 remains unchanged but receives human bookkeeping columns.
+    row_case1 = next(row for row in updated_rows if row["decision_id"] == "Case1")
+    assert row_case1["fine_eur"] == "100.000000"
+    assert row_case1["fine_amount_human_native"] == "100.000000"
+    assert row_case1["fine_currency_human"] == "EUR"
+
+    # Case2 should now reflect the human amount and update the ratio.
+    row_case2 = next(row for row in updated_rows if row["decision_id"] == "Case2")
+    assert row_case2["fine_eur"] == "300.000000"
+    assert float(row_case2["fine_to_turnover_ratio"]) == pytest.approx(
+        0.5, rel=1e-6
+    )
+    assert float(row_case2["fine_log1p"]) == pytest.approx(
+        math.log1p(300), rel=1e-6
+    )
+
+    # Case3 receives a converted GBP amount.
+    row_case3 = next(row for row in updated_rows if row["decision_id"] == "Case3")
+    assert row_case3["fine_eur"] == "1170.000000"
+    assert row_case3["fine_numeric_valid"] == "1"
+    assert row_case3["fine_positive"] == "1"
+    assert row_case3["fine_status"] == "DISCUSSED"
+    assert row_case3["fine_amount_human_native"] == "1000.000000"
+    assert row_case3["fine_currency_human"] == "GBP"
+
+    # Case4 has no human override.
+    row_case4 = next(row for row in updated_rows if row["decision_id"] == "Case4")
+    assert row_case4["fine_eur"] == "50.000000"
+    assert "fine_amount_human_native" not in row_case4
+
+
+def test_compare_fines_classifies_conflicts() -> None:
+    ai_fines = {
+        "Case1": FineRecord("Case1", 100.0, 100.0, "EUR", "100", "ai"),
+        "Case2": FineRecord("Case2", 200.0, 200.0, "EUR", "200", "ai"),
+        "Case3": FineRecord("Case3", None, None, None, "", "ai"),
+    }
+    human_fines = {
+        "Case1": FineRecord("Case1", 100.5, 100.5, "EUR", "100.5 EUR", "human"),
+        "Case2": FineRecord("Case2", 350.0, 1500.0, "PLN", "1500 PLN", "human"),
+        "Case4": FineRecord("Case4", 50.0, 50.0, "EUR", "50", "human"),
+    }
+
+    comparisons = compare_fines(ai_fines, human_fines, tolerance=1.0)
+
+    statuses = {comp.decision_id: comp.status for comp in comparisons}
+    assert statuses["Case1"] == "MATCH"
+    assert statuses["Case2"] == "CONFLICT"
+    assert statuses["Case3"] == "MISSING_BOTH"
+    assert statuses["Case4"] == "AI_MISSING"
+
+    summary = summarise_comparisons(comparisons)
+    assert isinstance(summary, ComparisonSummary)
+    assert summary.total == 4
+    assert summary.matches == 1
+    assert summary.conflicts == 1
+    assert summary.ai_missing == 1
+    assert summary.human_missing == 0
+    assert summary.missing_both == 1


### PR DESCRIPTION
## Summary
- add `scripts.analysis.fine_reconciliation` to compare AI and human fine annotations and apply overrides with currency conversion
- capture the current comparison snapshot in `research/fine_amounts_comparison.md`
- add targeted pytest coverage for parsing, overrides, and comparison logic

## Testing
- pytest tests/test_fine_reconciliation.py

------
https://chatgpt.com/codex/tasks/task_e_68dad439ea68832e8595338213f6d6ee